### PR TITLE
Fix minor spacing issue on GitHub button

### DIFF
--- a/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
+++ b/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
@@ -8,11 +8,8 @@ import DemoFlashcard from '../../demo-components/DemoFlashcard/DemoFlashcard'
 import DemoFlashcardForm from '../../demo-components/DemoFlashcardForm/DemoFlashcardForm'
 import DemoNav from '../../demo-components/DemoNav/DemoNav'
 import * as textsAPI from '../../../utilities/texts-api'
-import * as wordsAPI from '../../../utilities/words-api'
 import { Button, Dialog, DialogActions, DialogContent } from '@mui/material'
 import { FaRegWindowClose } from "react-icons/fa";
-import { PiStarLight } from "react-icons/pi";
-import { PiStarFill } from "react-icons/pi";
 import { GiCheckMark } from "react-icons/gi";
 import { PiRepeatBold } from "react-icons/pi";
 import { getWordInfo } from '../../../utilities/words-service'

--- a/src/index.css
+++ b/src/index.css
@@ -55,7 +55,6 @@ button {
 .demo-button {
   background-color: var(--primary);
   color: var(--darkest);
-  border: none;
   box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.1);
   gap: 10px;
 }
@@ -70,14 +69,14 @@ button {
 .github-button {
   background-color: var(--white);
   color: var(--primary);
-  border: 1px solid var(--primary);
+  outline: 1px solid var(--primary);
   gap: 10px;
 }
 
 .github-button:hover {
   background-color: var(--light);
   color: var(--darkest);
-  border: none;
+  outline: 1px solid var(--light);
 }
 
 .close-btn:hover {


### PR DESCRIPTION
Minor fix of a spacing issue with the buttons caused by the border on the GitHub button (hovering over buttons caused the image to wiggle). Removed border and changed to use `outline` instead.

Before:

https://github.com/user-attachments/assets/5770acc2-9602-47a3-b9b1-e61bc0d82f08

After:

https://github.com/user-attachments/assets/26ff7438-2d0c-4277-9145-1c2ccf6d9bc5

<sub><a href="https://huly.app/guest/knownative?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmE3YWQzZTdmMDllZGM1NjA2MjIwMDMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWJpZ2FpbGRhd3NvLWtub3duYXRpdmUtNjYzMjgxYjEtODdiZTE2ZDY5OS0yYTZiY2QiLCJwcm9kdWN0SWQiOiIifQ.k24vnpjqXfR2luhSkxOHaC-R68RWaX2V3Lg5QVGlXC4">Huly&reg;: <b>GITHB-39</b></a></sub>