### PR TITLE
Finished "Create sidebar for flashcard activity" issue (DEMO-23) [may also include commits for "Improve UI for Saved Words sidebar" issue] #39 (re-pulled)

### DIFF
--- a/src/demo/demo-components/DemoFlashcardForm/DemoFlashcardForm.css
+++ b/src/demo/demo-components/DemoFlashcardForm/DemoFlashcardForm.css
@@ -1,3 +1,8 @@
+.header {
+  text-align: left;
+  padding-left: 1rem;
+}
+
 .play-btn {
   margin-top: 3vmin;
   font-size: 1.1rem;

--- a/src/demo/demo-components/DemoFlashcardForm/DemoFlashcardForm.css
+++ b/src/demo/demo-components/DemoFlashcardForm/DemoFlashcardForm.css
@@ -1,13 +1,42 @@
 .header {
+  display: flex;
+  justify-content: space-between;
+}
+
+.arrowBack:hover {
+  background-color: var(--light);
+  border-radius: 0.7vmin;
+  cursor: pointer;
+}
+
+.FlashCardForm {
+  display: flex;
+  flex-direction: column;
+  padding: 3vmin 3vmin;
+  margin-top: 1rem;
+  width: 100%;
+  color: black;
+}
+
+.radio-buttons-group-label {
   text-align: left;
-  padding-left: 1rem;
+  margin-top: 1rem;
+}
+
+.radio-buttons-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.show-pinyin {
+  margin-top: 0.5rem;
 }
 
 .play-btn {
   margin-top: 3vmin;
   font-size: 1.1rem;
   padding: 1vmin 2vmin;
-  background-color: var(--slate);
+  background-color: #006769;
   color: white;
   transition: transform 0.3s ease-in-out;
 }

--- a/src/demo/demo-components/DemoFlashcardForm/DemoFlashcardForm.jsx
+++ b/src/demo/demo-components/DemoFlashcardForm/DemoFlashcardForm.jsx
@@ -6,8 +6,10 @@ import {
   FormControl,
   FormGroup,
   Switch,
+  Checkbox,
   FormLabel,
 } from "@mui/material";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 
 export default function DemoFlashcardForm({
   selectedFront,
@@ -15,31 +17,76 @@ export default function DemoFlashcardForm({
   showPinyin,
   setShowPinyin,
   handlePlay,
+  expandSidebar,
+  changeSidebarCategory,
 }) {
+  //function that closes the sidebar when you click on the arrow icon.
+  function handleBackArrowClick(e) {
+    const toolTipId = e.currentTarget.dataset.tooltipId;
+    expandSidebar();
+    changeSidebarCategory(toolTipId);
+  }
+
   return (
     <>
-      <div>
-        <h2 className="header">Learn</h2>
+      <div className="FlashCardForm">
+        <header className="header">
+          <h3>Learn</h3>
+          <div>
+            <ChevronLeftIcon
+              fontSize="large"
+              className="arrowBack"
+              data-tooltip-id="flashcards-tooltip"
+              onClick={handleBackArrowClick}
+            />
+          </div>
+        </header>
         <FormGroup>
           <FormControl>
-            <FormLabel id="radio-buttons-group-label">
-              Choose which to display on the front:
+            <FormLabel
+              id="radio-buttons-group-label"
+              className="radio-buttons-group-label"
+              sx={{ color: "black" }}
+            >
+              <p>Review your saved terms with a short quiz.</p>
+              <p>Choose which to display on the front:</p>
             </FormLabel>
             <RadioGroup
-              row
+              column
               aria-labelledby="demo-row-radio-buttons-group-label"
               name="row-radio-buttons-group"
+              className="radio-buttons-group"
             >
               <FormControlLabel
                 value="chinese"
-                control={<Radio />}
+                control={
+                  <Radio
+                    sx={{
+                      paddingTop: "0px",
+                      paddingBottom: "0px",
+                      "&.Mui-checked": {
+                        color: "#00b9bc",
+                      },
+                    }}
+                  />
+                }
                 label="Chinese"
                 checked={selectedFront === "chinese"}
                 onChange={() => setSelectedFront("chinese")}
               />
               <FormControlLabel
                 value="english"
-                control={<Radio />}
+                control={
+                  <Radio
+                    sx={{
+                      paddingTop: "0px",
+                      paddingBottom: "0px",
+                      "&.Mui-checked": {
+                        color: "#00b9bc",
+                      },
+                    }}
+                  />
+                }
                 label="English"
                 checked={selectedFront === "english"}
                 onChange={() => setSelectedFront("english")}
@@ -50,16 +97,23 @@ export default function DemoFlashcardForm({
         <FormGroup>
           <FormControlLabel
             control={
-              <Switch
+              <Checkbox
                 checked={showPinyin}
                 onChange={() => setShowPinyin(!showPinyin)}
+                sx={{
+                  color: "black",
+                  "&.Mui-checked": {
+                    color: "#00b9bc",
+                  },
+                }}
               />
             }
             label="Show pinyin"
+            className="show-pinyin"
           />
         </FormGroup>
         <button className="play-btn" onClick={handlePlay}>
-          Play!
+          Start Quiz
         </button>
       </div>
     </>

--- a/src/demo/demo-components/DemoFlashcardForm/DemoFlashcardForm.jsx
+++ b/src/demo/demo-components/DemoFlashcardForm/DemoFlashcardForm.jsx
@@ -1,45 +1,67 @@
-import './DemoFlashcardForm.css'
-import { Radio, RadioGroup, FormControlLabel, FormControl, FormGroup, Switch, FormLabel } from '@mui/material'
+import "./DemoFlashcardForm.css";
+import {
+  Radio,
+  RadioGroup,
+  FormControlLabel,
+  FormControl,
+  FormGroup,
+  Switch,
+  FormLabel,
+} from "@mui/material";
 
-export default function DemoFlashcardForm({ selectedFront, setSelectedFront, showPinyin, setShowPinyin, handlePlay }) {
-
-  return(
+export default function DemoFlashcardForm({
+  selectedFront,
+  setSelectedFront,
+  showPinyin,
+  setShowPinyin,
+  handlePlay,
+}) {
+  return (
     <>
       <div>
+        <h2 className="header">Learn</h2>
         <FormGroup>
           <FormControl>
-            <FormLabel id="radio-buttons-group-label">Choose which to display on the front:</FormLabel>
+            <FormLabel id="radio-buttons-group-label">
+              Choose which to display on the front:
+            </FormLabel>
             <RadioGroup
               row
               aria-labelledby="demo-row-radio-buttons-group-label"
               name="row-radio-buttons-group"
             >
-              <FormControlLabel 
-                value="chinese" 
-                control={<Radio />} 
-                label="Chinese" 
-                checked={selectedFront === 'chinese'}
-                onChange={() => setSelectedFront('chinese')}
+              <FormControlLabel
+                value="chinese"
+                control={<Radio />}
+                label="Chinese"
+                checked={selectedFront === "chinese"}
+                onChange={() => setSelectedFront("chinese")}
               />
-              <FormControlLabel 
-                value="english" 
-                control={<Radio />} 
-                label="English" 
-                checked={selectedFront === 'english'}
-                onChange={() => setSelectedFront('english')}
+              <FormControlLabel
+                value="english"
+                control={<Radio />}
+                label="English"
+                checked={selectedFront === "english"}
+                onChange={() => setSelectedFront("english")}
               />
             </RadioGroup>
           </FormControl>
         </FormGroup>
         <FormGroup>
-          <FormControlLabel 
-            control={<Switch checked={showPinyin} onChange={() => setShowPinyin(!showPinyin)} />} 
-            label="Show pinyin" 
+          <FormControlLabel
+            control={
+              <Switch
+                checked={showPinyin}
+                onChange={() => setShowPinyin(!showPinyin)}
+              />
+            }
+            label="Show pinyin"
           />
         </FormGroup>
-        <button className="play-btn" onClick={handlePlay}>Play!</button>
-
+        <button className="play-btn" onClick={handlePlay}>
+          Play!
+        </button>
       </div>
     </>
-  )
+  );
 }

--- a/src/demo/demo-components/DemoFlashcardForm/DemoFlashcardForm.jsx
+++ b/src/demo/demo-components/DemoFlashcardForm/DemoFlashcardForm.jsx
@@ -17,16 +17,8 @@ export default function DemoFlashcardForm({
   showPinyin,
   setShowPinyin,
   handlePlay,
-  expandSidebar,
-  changeSidebarCategory,
+  handleBackArrowClick,
 }) {
-  //function that closes the sidebar when you click on the arrow icon.
-  function handleBackArrowClick(e) {
-    const toolTipId = e.currentTarget.dataset.tooltipId;
-    expandSidebar();
-    changeSidebarCategory(toolTipId);
-  }
-
   return (
     <>
       <div className="FlashCardForm">

--- a/src/demo/demo-components/DemoNav/DemoNav.jsx
+++ b/src/demo/demo-components/DemoNav/DemoNav.jsx
@@ -1,60 +1,86 @@
-import './DemoNav.css'
+import "./DemoNav.css";
 import { TbCardsFilled } from "react-icons/tb";
 import { MdQuiz } from "react-icons/md";
 import { FaArrowsRotate } from "react-icons/fa6";
 import { ImExit } from "react-icons/im";
 import { FaRegQuestionCircle } from "react-icons/fa";
-import { Tooltip } from 'react-tooltip'
+import { Tooltip } from "react-tooltip";
 
-export default function DemoNav({ expandSidebar }) {
-
-  function handleCardsClick(evt) {
-    expandSidebar()
+export default function DemoNav({
+  expandSidebar,
+  changeSidebarCategory,
+  sidebarCategory,
+}) {
+  function handleCardsClick(e) {
+    const selectedIcon = e.currentTarget.dataset.tooltipId;
+    console.log("selected icon: ", selectedIcon);
+    //if there's no sidebar present, then expand the sidebar based on what the user clicked.
+    if (sidebarCategory === null) {
+      changeSidebarCategory(selectedIcon);
+      expandSidebar();
+      return;
+    }
+    //if the sidebar is present, but you're pressing a different button, just switch the content of the sidebar
+    if (sidebarCategory !== selectedIcon) {
+      changeSidebarCategory(selectedIcon);
+      return;
+    }
+    //if the sidebar is present, and you're clicking the same icon on the navbar, close the sidebar
+    if (sidebarCategory === selectedIcon) {
+      expandSidebar();
+      changeSidebarCategory(selectedIcon);
+      return;
+    }
   }
 
   return (
     <>
-      <div className='top-icons'>
-        <img src="/images/placeholder-logo.png" alt="logo" className="placeholder-logo" />
-        <TbCardsFilled 
-          className="side-nav-icon-top" 
-          onClick={handleCardsClick} 
-          data-tooltip-id="savedwords-tooltip" 
-          data-tooltip-content="Saved Words" 
-          data-tooltip-place="right" 
+      <div className="top-icons">
+        <img
+          src="/images/placeholder-logo.png"
+          alt="logo"
+          className="placeholder-logo"
+        />
+        <TbCardsFilled
+          className="side-nav-icon-top"
+          onClick={handleCardsClick}
+          data-tooltip-id="savedwords-tooltip"
+          data-tooltip-content="Saved Words"
+          data-tooltip-place="right"
         />
         <Tooltip id="savedwords-tooltip" />
-        <MdQuiz 
-          className="side-nav-icon-top" 
-          data-tooltip-id="flashcards-tooltip" 
-          data-tooltip-content="Flashcard Quiz" 
-          data-tooltip-place="right" 
+        <MdQuiz
+          className="side-nav-icon-top"
+          onClick={handleCardsClick}
+          data-tooltip-id="flashcards-tooltip"
+          data-tooltip-content="Flashcard Quiz"
+          data-tooltip-place="right"
         />
         <Tooltip id="flashcards-tooltip" />
-        <FaArrowsRotate 
-          className="side-nav-icon-top" 
-          data-tooltip-id="changetext-tooltip" 
-          data-tooltip-content="Change Text" 
-          data-tooltip-place="right" 
+        <FaArrowsRotate
+          className="side-nav-icon-top"
+          data-tooltip-id="changetext-tooltip"
+          data-tooltip-content="Change Text"
+          data-tooltip-place="right"
         />
         <Tooltip id="changetext-tooltip" />
       </div>
       <div className="bottom-icons">
-        <FaRegQuestionCircle  
-          className="side-nav-icon-bottom" 
-          data-tooltip-id="support-tooltip" 
-          data-tooltip-content="Support" 
-          data-tooltip-place="right" 
+        <FaRegQuestionCircle
+          className="side-nav-icon-bottom"
+          data-tooltip-id="support-tooltip"
+          data-tooltip-content="Support"
+          data-tooltip-place="right"
         />
         <Tooltip id="support-tooltip" />
-        <ImExit 
-          className="side-nav-icon-bottom" 
-          data-tooltip-id="exit-tooltip" 
-          data-tooltip-content="Exit Demo" 
-          data-tooltip-place="right" 
+        <ImExit
+          className="side-nav-icon-bottom"
+          data-tooltip-id="exit-tooltip"
+          data-tooltip-content="Exit Demo"
+          data-tooltip-place="right"
         />
         <Tooltip id="exit-tooltip" />
       </div>
     </>
-  )
+  );
 }

--- a/src/demo/demo-components/DemoSavedWord/DemoSavedWord.css
+++ b/src/demo/demo-components/DemoSavedWord/DemoSavedWord.css
@@ -1,26 +1,94 @@
 .SavedWord {
-  display: grid;
-  grid-template-columns: 30% 70%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  /* grid-template-columns: 30% 70%;
   align-items: center;
   text-align: left;
-  text-wrap: wrap;
+  text-wrap: wrap; */
   background-color: white;
-  color: var(--drk-txt);
-  padding: 2vmin 1vmin;
-  margin: .5vmin 1vmin;
+  color: black;
+  padding: 2vmin 3.5vmin;
+  margin: 0.5vmin 1vmin;
   border-bottom: 2px solid var(--medium);
-  border-radius: .5vmin;
+  border-radius: 0.5vmin;
   position: relative;
-  -webkit-box-shadow: 7px 7px 5px -8px rgba(0,0,0,0.4);
-  -moz-box-shadow: 7px 7px 5px -8px rgba(0,0,0,0.4);
-  box-shadow: 7px 7px 5px -8px rgba(0,0,0,0.4);
-
+  -webkit-box-shadow: 7px 7px 5px -8px rgba(235, 235, 235, 0.4);
+  -moz-box-shadow: 7px 7px 5px -8px rgba(235, 235, 235, 0.4);
+  box-shadow: 7px 7px 5px -8px rgba(235, 235, 235, 0.4);
 }
 
-.left-side {
+/* rgba(0, 0, 0, 0.4);*/
+
+/* .left-side {
   display: flex;
   margin-left: 4vmin;
   position: relative;
+} */
+
+.edit-menu-button {
+  color: #00b9bc;
+  position: absolute;
+  top: 1vmin;
+  right: 1vmin;
+  font-size: 1.3rem;
+  transition: transform 0.3s ease-in-out;
+  border-radius: 50%;
+}
+
+.edit-menu-button:hover {
+  background-color: #00b9bc;
+  transform: scale(1.3);
+  cursor: pointer;
+  color: white;
+}
+
+.edit-delete-menu {
+  width: 50%;
+  min-width: 120px;
+  box-shadow: 7px 7px 5px -8px black;
+  position: absolute;
+  top: 1.2vmin;
+  left: 95%;
+}
+
+.edit-delete-menu section {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 1rem;
+  padding: 0.5vmin 1vmin;
+}
+
+.edit-delete-menu section p {
+  margin-bottom: 0px;
+}
+
+.edit-button {
+  background-color: #e1faf7;
+  color: #24312f;
+  border-top-left-radius: 10%;
+  border-top-right-radius: 10%;
+}
+
+.edit-button:hover {
+  cursor: pointer;
+  color: #e1faf7;
+  background-color: #24312f;
+}
+
+.delete-button {
+  background-color: #ffe6e6;
+  color: #660000;
+  border-bottom-left-radius: 10%;
+  border-bottom-right-radius: 10%;
+}
+
+.delete-button:hover {
+  cursor: pointer;
+  background-color: #660000;
+  color: #ffe6e6;
 }
 
 .word-delete-btn {
@@ -32,30 +100,34 @@
   color: var(--red);
 }
 
-.char-pinyin {
+/* .char-pinyin {
   display: flex;
   flex-direction: column;
   align-items: center;
   text-align: center;
-}
+} */
 
 .char-pinyin > .char {
-  font-size: 1.4rem;
+  font-size: 1.7rem;
+  margin-bottom: 0px;
+  color: black;
 }
 
 .char-pinyin > .pinyin {
-  font-size: .6rem;
+  font-size: 0.8rem;
+  margin-bottom: 0px;
+  color: grey;
 }
 
-.meaning {
+/* .meaning {
   margin-left: 1.4rem;
-}
+} */
 
-.right-side {
+/* .right-side {
   display: flex;
   justify-content: space-between;
   align-items: center;
-}
+} */
 
 .updateMeaningForm {
   display: flex;
@@ -72,7 +144,7 @@
   width: 70%;
   padding: 1vmin;
   font-size: 1rem;
-  border-radius: .8vmin;
+  border-radius: 0.8vmin;
   border: 1px solid var(--gray-lt);
 }
 

--- a/src/demo/demo-components/DemoSavedWord/DemoSavedWord.css
+++ b/src/demo/demo-components/DemoSavedWord/DemoSavedWord.css
@@ -27,7 +27,7 @@
   position: relative;
 } */
 
-.edit-menu-button {
+.edit-menu-icon {
   color: #00b9bc;
   position: absolute;
   top: 1vmin;
@@ -37,7 +37,7 @@
   border-radius: 50%;
 }
 
-.edit-menu-button:hover {
+.edit-menu-icon:hover {
   background-color: #00b9bc;
   transform: scale(1.3);
   cursor: pointer;
@@ -91,14 +91,14 @@
   color: #ffe6e6;
 }
 
-.word-delete-btn {
+/* .word-delete-btn {
   position: absolute;
   font-size: 2.5vmin;
   cursor: pointer;
   top: 1.5vmin;
   left: -3.5vmin;
   color: var(--red);
-}
+} */
 
 /* .char-pinyin {
   display: flex;
@@ -129,7 +129,7 @@
   align-items: center;
 } */
 
-.updateMeaningForm {
+/* .updateMeaningForm {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -150,9 +150,9 @@
 
 .updateMeaningForm > input:focus {
   outline-color: var(--teal);
-}
+} */
 
-.submit-btn {
+/* .submit-btn {
   font-size: 2.7vmin;
   background-color: var(--white);
 }
@@ -175,4 +175,4 @@
 .edit-btn:hover,
 .submit-btn:hover {
   cursor: pointer;
-}
+} */

--- a/src/demo/demo-components/DemoSavedWord/DemoSavedWord.jsx
+++ b/src/demo/demo-components/DemoSavedWord/DemoSavedWord.jsx
@@ -16,42 +16,48 @@ export default function DemoSavedWord({
   const [formData, setFormData] = useState({
     meaning: word.meaning,
   });
+
+  //NEW CODE ----------------------
+  //state that will keep track of IF the edit menu is open for that particular word. Also, isMouseInsideMenu is utilized in order to track whether the cursor is inside of the menu. The menu is set to close when your mouse is outside of the menu.
   const [isEditMenuOpen, setIsEditMenuOpen] = useState(false);
   const [isMouseInsideMenu, setIsMouseInsideMenu] = useState(false);
 
-  function handleEditMenuClick() {
+  //clicking the edit icon will open up the menu or close the menu if the menu is already open
+  function handleEditIconClick() {
     setIsEditMenuOpen((currentState) => !currentState);
   }
 
+  //if the mouse leaves the saved word card element that is associated with the menu, close the menu if the menu is already open.
   function handleMouseleaveCard() {
-    setTimeout(() => {
-      if (!isMouseInsideMenu) {
-        setIsEditMenuOpen(false);
-      }
-    }, 100);
+    if (!isMouseInsideMenu) {
+      setIsEditMenuOpen(false);
+    }
   }
 
+  //if the mouse enters the menu, set state of IsMouseInsideMenu to TRUE. (it allows you navigate edit or delete buttons as you need to)
   function handleMouseEnterMenu() {
     setIsMouseInsideMenu(true);
   }
 
+  //if you enter the menu and then leave the menu with your mouse, it automatically closes the menu.
   function handleEditMenuMouseleave() {
     setIsMouseInsideMenu(false);
     setIsEditMenuOpen(false);
   }
 
+  //I WILL REVISIT THE COMMENTED CODE BELOW WHEN I CREATE THE MODAL. I just commented it out for now so that I wouldn't get confused when I adjust things.
+  /*
   function handleChange(evt) {
     const newFormData = {
       ...formData,
       [evt.target.name]: evt.target.value,
     };
     setFormData(newFormData);
-  }
+  } 
 
-  //reimplement later when I create the modal form for the edit form.
-  // function handleEditClick() {
-  //   setIsEditingWord(word._id);
-  // }
+  function handleEditClick() {
+    setIsEditingWord(word._id);
+  } 
 
   function handleUpdateMeaning(word) {
     if (word.meaning === formData.meaning) {
@@ -59,7 +65,7 @@ export default function DemoSavedWord({
       return;
     }
     updateMeaning(word, formData.meaning);
-  }
+  } */
 
   function handleDeleteWord(word) {
     setIsEditMenuOpen(false);
@@ -68,10 +74,12 @@ export default function DemoSavedWord({
 
   return (
     <article className="SavedWord" onMouseLeave={handleMouseleaveCard}>
+      {/* This the three dots. I placed it absolutely to the corner of every saved word. */}
       <BiDotsVerticalRounded
-        className="edit-menu-button"
-        onClick={handleEditMenuClick}
+        className="edit-menu-icon"
+        onClick={handleEditIconClick}
       />
+      {/* If the editMenuOpen state variable is true, display the edit/delete menu. */}
       {isEditMenuOpen && (
         <article
           className="edit-delete-menu"
@@ -101,29 +109,10 @@ export default function DemoSavedWord({
         <p className="char zh">{word.charGroup} </p>
       </section>
       <section>
-        {isEditingWord ? (
-          <form
-            className="updateMeaningForm"
-            onSubmit={() => handleUpdateMeaning(word)}
-          >
-            <input
-              type="text"
-              name="meaning"
-              value={formData.meaning}
-              onChange={handleChange}
-            />
-            <button className="submit-btn" type="submit">
-              <FaCheckSquare className="submit-icon" />
-            </button>
-          </form>
-        ) : (
-          <div>
-            <div>{word.meaning}</div>
-            {/* <div className="edit-btn" onClick={handleEditClick}>
+        <span>{word.meaning}</span>
+        {/* <div className="edit-btn" onClick={handleEditClick}>
               <FaRegEdit />
             </div> */}
-          </div>
-        )}
       </section>
     </article>
   );
@@ -174,4 +163,33 @@ return (
     </article>
   );
 }
+//KEEPING OLD CODE HERE IN CASE I NEED TO REFERENCE IT.
+        <p className="char zh">{word.charGroup} </p>
+      </section>
+      <section>
+        {isEditingWord ? (
+          <form
+            className="updateMeaningForm"
+            onSubmit={() => handleUpdateMeaning(word)}
+          >
+            <input
+              type="text"
+              name="meaning"
+              value={formData.meaning}
+              onChange={handleChange}
+            />
+            <button className="submit-btn" type="submit">
+              <FaCheckSquare className="submit-icon" />
+            </button>
+          </form>
+        ) : (
+          <div>
+            <div>{word.meaning}</div>
+            {/* <div className="edit-btn" onClick={handleEditClick}>
+              <FaRegEdit />
+            </div>}
+            </div>
+          )}
+        </section>
+      </article>
 */

--- a/src/demo/demo-components/DemoSavedWord/DemoSavedWord.jsx
+++ b/src/demo/demo-components/DemoSavedWord/DemoSavedWord.jsx
@@ -1,77 +1,177 @@
-import './DemoSavedWord.css'
-import { useState } from 'react'
+import "./DemoSavedWord.css";
+import { useState } from "react";
+import { BiDotsVerticalRounded } from "react-icons/bi";
 import { FaRegEdit } from "react-icons/fa";
+import { FaPencilAlt } from "react-icons/fa";
 import { FaCheckSquare } from "react-icons/fa";
 import { PiTrashLight } from "react-icons/pi";
 
-
-export default function DemoSavedWord({ word, updateMeaning, isEditingWord, setIsEditingWord, deleteWord }) {
-
+export default function DemoSavedWord({
+  word,
+  updateMeaning,
+  isEditingWord,
+  setIsEditingWord,
+  deleteWord,
+}) {
   const [formData, setFormData] = useState({
-    meaning: word.meaning
-  })
+    meaning: word.meaning,
+  });
+  const [isEditMenuOpen, setIsEditMenuOpen] = useState(false);
+  const [isMouseInsideMenu, setIsMouseInsideMenu] = useState(false);
+
+  function handleEditMenuClick() {
+    setIsEditMenuOpen((currentState) => !currentState);
+  }
+
+  function handleMouseleaveCard() {
+    setTimeout(() => {
+      if (!isMouseInsideMenu) {
+        setIsEditMenuOpen(false);
+      }
+    }, 100);
+  }
+
+  function handleMouseEnterMenu() {
+    setIsMouseInsideMenu(true);
+  }
+
+  function handleEditMenuMouseleave() {
+    setIsMouseInsideMenu(false);
+    setIsEditMenuOpen(false);
+  }
 
   function handleChange(evt) {
     const newFormData = {
       ...formData,
-      [evt.target.name]: evt.target.value
+      [evt.target.name]: evt.target.value,
     };
-    setFormData(newFormData)
+    setFormData(newFormData);
   }
 
-  function handleEditClick() {
-    setIsEditingWord(word._id)
-  }
+  //reimplement later when I create the modal form for the edit form.
+  // function handleEditClick() {
+  //   setIsEditingWord(word._id);
+  // }
 
   function handleUpdateMeaning(word) {
     if (word.meaning === formData.meaning) {
-      setIsEditingWord(null)
-      return
+      setIsEditingWord(null);
+      return;
     }
-    updateMeaning(word, formData.meaning)
+    updateMeaning(word, formData.meaning);
   }
 
   function handleDeleteWord(word) {
-    deleteWord(word)
+    setIsEditMenuOpen(false);
+    deleteWord(word);
   }
-  
+
   return (
-    <div className="SavedWord">
-
-      {/* grid column 1 */}
-
-      <div className="left-side">
-      {isEditingWord &&
-        <div className="word-delete-btn" onClick={() => handleDeleteWord(word)}><PiTrashLight /></div> }
-        <div className="char-pinyin">
-          <p className="pinyin"> { word.pinyin } </p>
-          <p className="char zh">{ word.charGroup } </p> 
-        </div>
-      </div>
-      
-
-      {/* grid column 2 */}
-
-      <div className="meaning">
+    <article className="SavedWord" onMouseLeave={handleMouseleaveCard}>
+      <BiDotsVerticalRounded
+        className="edit-menu-button"
+        onClick={handleEditMenuClick}
+      />
+      {isEditMenuOpen && (
+        <article
+          className="edit-delete-menu"
+          onMouseEnter={handleMouseEnterMenu}
+          onMouseLeave={handleEditMenuMouseleave}
+        >
+          <section className="edit-button">
+            <p>Edit</p>
+            <FaPencilAlt />
+          </section>
+          <section className="delete-button" onClick={handleDeleteWord}>
+            <p>Delete</p>
+            <PiTrashLight />
+          </section>
+        </article>
+      )}
+      <section className="char-pinyin">
+        {/* {isEditingWord && (
+          <div
+            className="word-delete-btn"
+            onClick={() => handleDeleteWord(word)}
+          >
+            <PiTrashLight />
+          </div>
+        )} */}
+        <p className="pinyin"> {word.pinyin} </p>
+        <p className="char zh">{word.charGroup} </p>
+      </section>
+      <section>
         {isEditingWord ? (
-          <form className="updateMeaningForm" onSubmit={() => handleUpdateMeaning(word)}>
+          <form
+            className="updateMeaningForm"
+            onSubmit={() => handleUpdateMeaning(word)}
+          >
             <input
               type="text"
               name="meaning"
               value={formData.meaning}
               onChange={handleChange}
             />
-            <button className="submit-btn" type="submit" ><FaCheckSquare className="submit-icon" /></button>
+            <button className="submit-btn" type="submit">
+              <FaCheckSquare className="submit-icon" />
+            </button>
           </form>
         ) : (
-          <div className="right-side">
-            <div>{ word.meaning }</div>
-            <div className="edit-btn" onClick={handleEditClick}><FaRegEdit /></div>
+          <div>
+            <div>{word.meaning}</div>
+            {/* <div className="edit-btn" onClick={handleEditClick}>
+              <FaRegEdit />
+            </div> */}
           </div>
         )}
-      </div>
-
-    </div>
-
-  )
+      </section>
+    </article>
+  );
 }
+
+/* 
+OLD CODE -> to keep for reference. 
+return (
+    <article className="SavedWord">
+      <BiDotsVerticalRounded />
+      <section className="char-pinyin">
+         {isEditingWord && (
+          <div
+            className="word-delete-btn"
+            onClick={() => handleDeleteWord(word)}
+          >
+            <PiTrashLight />
+          </div>
+        )} 
+        <p className="pinyin"> {word.pinyin} </p>
+        <p className="char zh">{word.charGroup} </p>
+      </section>
+      <section>
+        {isEditingWord ? (
+          <form
+            className="updateMeaningForm"
+            onSubmit={() => handleUpdateMeaning(word)}
+          >
+            <input
+              type="text"
+              name="meaning"
+              value={formData.meaning}
+              onChange={handleChange}
+            />
+            <button className="submit-btn" type="submit">
+              <FaCheckSquare className="submit-icon" />
+            </button>
+          </form>
+        ) : (
+          <div>
+            <div>{word.meaning}</div>
+             <div className="edit-btn" onClick={handleEditClick}>
+              <FaRegEdit />
+            </div> 
+          </div>
+        )}
+      </section>
+    </article>
+  );
+}
+*/

--- a/src/demo/demo-components/DemoSavedWordsList/DemoSavedWordsList.css
+++ b/src/demo/demo-components/DemoSavedWordsList/DemoSavedWordsList.css
@@ -5,13 +5,21 @@
   width: 100%;
   background-color: #f5faf9;
   color: black;
+  margin-top: 2vmin;
 }
 
-.SavedWordsList > h1 {
+.arrowBack:hover {
+  background-color: var(--light);
+  border-radius: 0.7vmin;
+  cursor: pointer;
+}
+
+/* .SavedWordsList > h1 {
   align-self: flex-start;
   margin: 3vmin;
   padding-left: 2vmin;
-}
+} */
+
 .demo-saved-words-header-container {
   display: flex;
   justify-content: space-between;
@@ -26,7 +34,7 @@
   margin: 0 3vmin;
 } */
 
-.study-btn {
+/* .study-btn {
   display: flex;
   flex-direction: column;
   position: relative;
@@ -58,13 +66,17 @@
   50% {
     transform: rotate(-5deg);
   }
-}
+} */
 
-.study-btn-txt {
+/* .study-btn-txt {
   font-size: 0.8rem;
   position: absolute;
   right: 5vmin;
   bottom: 1vmin;
+} */
+
+.saved-words-list-container {
+  margin-top: 2vmin;
 }
 
 .add-word-btn {

--- a/src/demo/demo-components/DemoSavedWordsList/DemoSavedWordsList.css
+++ b/src/demo/demo-components/DemoSavedWordsList/DemoSavedWordsList.css
@@ -1,10 +1,10 @@
 .SavedWordsList {
   display: flex;
   flex-direction: column;
-  padding: 1vmin 1vmin;
+  padding: 2vmin 2vmin;
   width: 100%;
-  background-color: #F5FAF9;
-  color: var(--drk-txt);
+  background-color: #f5faf9;
+  color: black;
 }
 
 .SavedWordsList > h1 {
@@ -12,11 +12,19 @@
   margin: 3vmin;
   padding-left: 2vmin;
 }
+.demo-saved-words-header-container {
+  display: flex;
+  justify-content: space-between;
+}
+.sidebar-heading {
+  text-align: left;
+  font-size: 1.5rem;
+}
 
-.sidebar-heading ~ p {
+/* .sidebar-heading ~ p {
   text-align: left;
   margin: 0 3vmin;
-}
+} */
 
 .study-btn {
   display: flex;
@@ -31,7 +39,7 @@
   width: 50%;
   position: absolute;
   right: -4.5vmin;
-  bottom: -.5vmin;
+  bottom: -0.5vmin;
   transform: rotate(5deg);
   transition: transform 0.3s ease-in-out, color 0.3s ease-in-out;
   cursor: pointer;
@@ -43,7 +51,8 @@
 }
 
 @keyframes wiggle {
-  0%, 100% {
+  0%,
+  100% {
     transform: rotate(5deg);
   }
   50% {
@@ -52,8 +61,22 @@
 }
 
 .study-btn-txt {
-  font-size: .8rem;
+  font-size: 0.8rem;
   position: absolute;
   right: 5vmin;
   bottom: 1vmin;
+}
+
+.add-word-btn {
+  margin-top: 3vmin;
+  font-size: 1.1rem;
+  padding: 1vmin 2vmin;
+  background-color: #006769;
+  color: white;
+  transition: transform 0.3s ease-in-out;
+}
+
+.add-word-btn:hover {
+  background-color: var(--teal);
+  transform: scale(1.1);
 }

--- a/src/demo/demo-components/DemoSavedWordsList/DemoSavedWordsList.jsx
+++ b/src/demo/demo-components/DemoSavedWordsList/DemoSavedWordsList.jsx
@@ -31,9 +31,10 @@ export default function DemoSavedWordsList({
         <h1 className="sidebar-heading">Saved Words</h1>
         <ChevronLeftIcon
           fontSize="large"
-          className="arrowBack"
           data-tooltip-id="savedwords-tooltip"
           onClick={handleBackArrowClick}
+          className="arrowBack"
+          color="#006769"
         />
       </header>
       {savedWords.length === 0 ? (
@@ -48,10 +49,12 @@ export default function DemoSavedWordsList({
       ) : (
         <>
           {/* <div className="study-btn">
-          <TbCardsFilled className="study-icon" onClick={handleOpen} />
-          <p className="study-btn-txt"> </p>
-        </div> */}
-          {!gameInProgress && savedWordItems}
+            <TbCardsFilled className="study-icon" onClick={handleOpen} />
+            <p className="study-btn-txt"> </p>
+          </div> */}
+          <article className="saved-words-list-container">
+            {!gameInProgress && savedWordItems}
+          </article>
         </>
       )}
       <button className="add-word-btn">+</button>

--- a/src/demo/demo-components/DemoSavedWordsList/DemoSavedWordsList.jsx
+++ b/src/demo/demo-components/DemoSavedWordsList/DemoSavedWordsList.jsx
@@ -1,11 +1,18 @@
-import './DemoSavedWordsList.css'
-import { useState } from 'react'
-import DemoSavedWord from '../DemoSavedWord/DemoSavedWord'
+import "./DemoSavedWordsList.css";
+import { useState } from "react";
+import DemoSavedWord from "../DemoSavedWord/DemoSavedWord";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import { TbCardsFilled } from "react-icons/tb";
 
-export default function DemoSavedWordsList({ savedWords, updateMeaning, deleteWord, handleOpen, gameInProgress }) {
-
-  const [editingWord, setEditingWord] = useState(null)
+export default function DemoSavedWordsList({
+  savedWords,
+  updateMeaning,
+  deleteWord,
+  handleOpen,
+  gameInProgress,
+  handleBackArrowClick,
+}) {
+  const [editingWord, setEditingWord] = useState(null);
 
   const savedWordItems = savedWords.map((word) => (
     <DemoSavedWord
@@ -16,25 +23,38 @@ export default function DemoSavedWordsList({ savedWords, updateMeaning, deleteWo
       setIsEditingWord={setEditingWord}
       deleteWord={deleteWord}
     />
-  ))
+  ));
 
   return (
     <div className="SavedWordsList">
-      <h1 className="sidebar-heading">Saved Words</h1>
-      { savedWords.length === 0 ? (
+      <header className="demo-saved-words-header-container">
+        <h1 className="sidebar-heading">Saved Words</h1>
+        <ChevronLeftIcon
+          fontSize="large"
+          className="arrowBack"
+          data-tooltip-id="savedwords-tooltip"
+          onClick={handleBackArrowClick}
+        />
+      </header>
+      {savedWords.length === 0 ? (
         <>
-          <p>No words have been saved yet!</p><br></br>
-          <p>Get started by navigating to the Study tab and selecting some words you'd like to study.</p>
+          <p>No words have been saved yet!</p>
+          <br></br>
+          <p>
+            Get started by navigating to the Study tab and selecting some words
+            you'd like to study.
+          </p>
         </>
       ) : (
         <>
-        <div className="study-btn">
+          {/* <div className="study-btn">
           <TbCardsFilled className="study-icon" onClick={handleOpen} />
           <p className="study-btn-txt"> </p>
-        </div>
-        { !gameInProgress && savedWordItems}
+        </div> */}
+          {!gameInProgress && savedWordItems}
         </>
       )}
+      <button className="add-word-btn">+</button>
     </div>
-  )
+  );
 }

--- a/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
+++ b/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
@@ -201,6 +201,13 @@ export default function DemoTextPage({ getText, updateText }) {
     setExpandedSidebar(!expandedSidebar);
   }
 
+  //function that closes the sidebar when you click on the arrow icon.
+  function handleBackArrowClick(e) {
+    const toolTipId = e.currentTarget.dataset.tooltipId;
+    expandSidebar();
+    changeSidebarCategory(toolTipId);
+  }
+
   return !text ? (
     "Loading ..."
   ) : (
@@ -227,6 +234,7 @@ export default function DemoTextPage({ getText, updateText }) {
               deleteWord={deleteWord}
               handleOpen={handleOpen}
               gameInProgress={gameInProgress}
+              handleBackArrowClick={handleBackArrowClick}
             />
           )}
           {sidebarCategory === "flashcards-tooltip" && (
@@ -238,6 +246,7 @@ export default function DemoTextPage({ getText, updateText }) {
               showPinyin={showPinyin}
               setShowPinyin={setShowPinyin}
               handlePlay={handlePlay}
+              handleBackArrowClick={handleBackArrowClick}
             />
           )}
         </aside>

--- a/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
+++ b/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
@@ -241,7 +241,7 @@ export default function DemoTextPage({ getText, updateText }) {
               gameInProgress={gameInProgress}
             />
           )}
-          {sidebarCategory === "flashcards-tooltip" && <h1>Learn</h1>}
+          {sidebarCategory === "flashcards-tooltip" && <DemoFlashcardForm />}
         </aside>
       )}
 

--- a/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
+++ b/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
@@ -184,12 +184,11 @@ export default function DemoTextPage({ getText, updateText }) {
     setOpen(true);
   }
 
-  //state that will be used to determine which sidebar to present based on which sidebar is clicked.
+  //state that will be used to store data that will determine which sidebar content to present based on which sidebar is clicked.
   const [sidebarCategory, setSidebarCategory] = useState(null);
 
+  //this function will change the type of content that should be displayed on the sidebar whenever one of the nav buttons is clicked
   function changeSidebarCategory(selectedIcon) {
-    console.log("changesidebarcat ", selectedIcon);
-    console.log("pre-change category:", sidebarCategory);
     if (sidebarCategory === selectedIcon) {
       setSidebarCategory(null);
     } else {
@@ -197,6 +196,7 @@ export default function DemoTextPage({ getText, updateText }) {
     }
   }
 
+  //function that physically expands the sidebar
   function expandSidebar() {
     setExpandedSidebar(!expandedSidebar);
   }
@@ -217,19 +217,7 @@ export default function DemoTextPage({ getText, updateText }) {
         />
       </nav>
 
-      {/* NOTE TO SELF: re-create this code so that there is some conditional rendering regarding which sidebar is displayed depending on what is clicked */}
-      {/* {expandedSidebar && (
-        <aside className="sidebar">
-          <DemoSavedWordsList
-            savedWords={localSavedWords}
-            updateMeaning={updateMeaning}
-            deleteWord={deleteWord}
-            handleOpen={handleOpen}
-            gameInProgress={gameInProgress}
-          />
-        </aside>
-      )} */}
-
+      {/* Conditional rendering, dependent on the values of expandedSidbar and sidebarCategory, that will determine if the sidebar is displayed and what content is displayed. */}
       {expandedSidebar && (
         <aside className="sidebar">
           {sidebarCategory === "savedwords-tooltip" && (
@@ -241,9 +229,32 @@ export default function DemoTextPage({ getText, updateText }) {
               gameInProgress={gameInProgress}
             />
           )}
-          {sidebarCategory === "flashcards-tooltip" && <DemoFlashcardForm />}
+          {sidebarCategory === "flashcards-tooltip" && (
+            <DemoFlashcardForm
+              expandSidebar={expandSidebar}
+              changeSidebarCategory={changeSidebarCategory}
+              selectedFront={selectedFront}
+              setSelectedFront={setSelectedFront}
+              showPinyin={showPinyin}
+              setShowPinyin={setShowPinyin}
+              handlePlay={handlePlay}
+            />
+          )}
         </aside>
       )}
+
+      {/* OLD CODE */}
+      {/* {expandedSidebar && (
+        <aside className="sidebar">
+          <DemoSavedWordsList
+            savedWords={localSavedWords}
+            updateMeaning={updateMeaning}
+            deleteWord={deleteWord}
+            handleOpen={handleOpen}
+            gameInProgress={gameInProgress}
+          />
+        </aside>
+      )} */}
 
       <Dialog
         open={open}

--- a/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
+++ b/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
@@ -1,68 +1,72 @@
-import { useState, useEffect } from 'react'
-import './DemoTextPage.css'
-import DemoStudyText from '../../demo-components/DemoStudyText/DemoStudyText'
-import DemoReadText from '../../demo-components/DemoReadText/DemoReadText'
-import DemoTranslateText from '../../demo-components/DemoTranslateText/DemoTranslateText'
-import DemoSavedWordsList from '../../demo-components/DemoSavedWordsList/DemoSavedWordsList'
-import DemoFlashcard from '../../demo-components/DemoFlashcard/DemoFlashcard'
-import DemoFlashcardForm from '../../demo-components/DemoFlashcardForm/DemoFlashcardForm'
-import DemoNav from '../../demo-components/DemoNav/DemoNav'
-import * as textsAPI from '../../../utilities/texts-api'
-import * as wordsAPI from '../../../utilities/words-api'
-import { Button, Dialog, DialogActions, DialogContent } from '@mui/material'
+import { useState, useEffect } from "react";
+import "./DemoTextPage.css";
+import DemoStudyText from "../../demo-components/DemoStudyText/DemoStudyText";
+import DemoReadText from "../../demo-components/DemoReadText/DemoReadText";
+import DemoTranslateText from "../../demo-components/DemoTranslateText/DemoTranslateText";
+import DemoSavedWordsList from "../../demo-components/DemoSavedWordsList/DemoSavedWordsList";
+import DemoFlashcard from "../../demo-components/DemoFlashcard/DemoFlashcard";
+import DemoFlashcardForm from "../../demo-components/DemoFlashcardForm/DemoFlashcardForm";
+import DemoNav from "../../demo-components/DemoNav/DemoNav";
+import * as textsAPI from "../../../utilities/texts-api";
+import * as wordsAPI from "../../../utilities/words-api";
+import { Button, Dialog, DialogActions, DialogContent } from "@mui/material";
 import { FaRegWindowClose } from "react-icons/fa";
 import { PiStarLight } from "react-icons/pi";
 import { PiStarFill } from "react-icons/pi";
 import { GiCheckMark } from "react-icons/gi";
 import { PiRepeatBold } from "react-icons/pi";
-import { getWordInfo } from '../../../utilities/words-service'
+import { getWordInfo } from "../../../utilities/words-service";
 //import word from '../../../../models/word'
 
 export default function DemoTextPage({ getText, updateText }) {
-
   const text = {
-    _id: '1',
-    title: '10 個台灣人最愛去的日本城市！',
-    content: '位在日本本州中部的靜岡縣，鄰近神奈川縣，有著日本最高、最著名的世界遺產「富士山」，大家最喜歡去的景點之一「伊豆半島」更是連日本人都非常熱愛的度假勝地，還有熱海沙灘、夢幻景點大井川鐵路等。靜岡縣南部緊鄰太平洋，眺望廣闊綿延的海岸線，十分悠閒，如果喜愛休閒輕鬆的旅程，它會是你的好選擇！此外，去過靜岡縣「伊豆仙人掌動物園」的網友表示，「可以很親近不同的小動物，隻隻都會賣萌賺零食。水豚非常親人，袋鼠十分慵懶，看他們浸溫泉，可以看足一小時」、「水豚太可愛了，樂園小小的但規劃的很不錯，可以逛完大室山後來走走」，也推薦列入行程中喔。',
-    source: 'https://www.housefeel.com.tw/article/%E6%97%A5%E6%9C%AC%E6%97%85%E9%81%8A-%E6%97%A5%E6%9C%AC%E6%99%AF%E9%BB%9E-%E6%97%A5%E6%9C%AC%E8%A7%80%E5%85%89-%E6%97%A5%E6%9C%AC%E5%9F%8E%E5%B8%82/',
+    _id: "1",
+    title: "10 個台灣人最愛去的日本城市！",
+    content:
+      "位在日本本州中部的靜岡縣，鄰近神奈川縣，有著日本最高、最著名的世界遺產「富士山」，大家最喜歡去的景點之一「伊豆半島」更是連日本人都非常熱愛的度假勝地，還有熱海沙灘、夢幻景點大井川鐵路等。靜岡縣南部緊鄰太平洋，眺望廣闊綿延的海岸線，十分悠閒，如果喜愛休閒輕鬆的旅程，它會是你的好選擇！此外，去過靜岡縣「伊豆仙人掌動物園」的網友表示，「可以很親近不同的小動物，隻隻都會賣萌賺零食。水豚非常親人，袋鼠十分慵懶，看他們浸溫泉，可以看足一小時」、「水豚太可愛了，樂園小小的但規劃的很不錯，可以逛完大室山後來走走」，也推薦列入行程中喔。",
+    source:
+      "https://www.housefeel.com.tw/article/%E6%97%A5%E6%9C%AC%E6%97%85%E9%81%8A-%E6%97%A5%E6%9C%AC%E6%99%AF%E9%BB%9E-%E6%97%A5%E6%9C%AC%E8%A7%80%E5%85%89-%E6%97%A5%E6%9C%AC%E5%9F%8E%E5%B8%82/",
     favorite: false,
     archived: false,
-    easierText: '',
-  }
+    easierText: "",
+  };
 
-  const [activeTab, setActiveTab] = useState('read')
+  const [activeTab, setActiveTab] = useState("read");
 
   // --- SAVED WORDS ---
   const [localSavedWords, setLocalSavedWords] = useState(
-    (JSON.parse(localStorage.getItem("stringifiedWords") === null)) ?
-      [] : JSON.parse(localStorage.getItem("stringifiedWords"))
-  )
-  const [savedWords, setSavedWords] = useState([])
-  const [activeWord, setActiveWord] = useState(null)
-  const [expandedSidebar, setExpandedSidebar] = useState(false)
+    JSON.parse(localStorage.getItem("stringifiedWords") === null)
+      ? []
+      : JSON.parse(localStorage.getItem("stringifiedWords"))
+  );
+  const [savedWords, setSavedWords] = useState([]);
+  const [activeWord, setActiveWord] = useState(null);
+  const [expandedSidebar, setExpandedSidebar] = useState(false);
 
   // --- POPUP ---
-  const [showPopup, setShowPopup] = useState(false)
+  const [showPopup, setShowPopup] = useState(false);
 
   // --- FLASHCARDS ---
-  const [open, setOpen] = useState(false)
-  const [flashcards, setFlashcards] = useState([])
-  const [selectedFront, setSelectedFront] = useState('chinese')
-  const [showPinyin, setShowPinyin] = useState(true)
-  const [gameInProgress, setGameInProgress] = useState(false)
-  const [correctCount, setCorrectCount] = useState(0)
-  const [remainingCount, setRemainingCount] = useState(0)
+  const [open, setOpen] = useState(false);
+  const [flashcards, setFlashcards] = useState([]);
+  const [selectedFront, setSelectedFront] = useState("chinese");
+  const [showPinyin, setShowPinyin] = useState(true);
+  const [gameInProgress, setGameInProgress] = useState(false);
+  const [correctCount, setCorrectCount] = useState(0);
+  const [remainingCount, setRemainingCount] = useState(0);
 
-  function expandSidebar() {
-    setExpandedSidebar(!expandedSidebar)
-  }
-
-  useEffect(function() {
-    function setLocalStorage () {
-      localStorage.setItem("stringifiedWords", JSON.stringify(localSavedWords))
-    }
-    setLocalStorage()
-  }, [localSavedWords])
+  useEffect(
+    function () {
+      function setLocalStorage() {
+        localStorage.setItem(
+          "stringifiedWords",
+          JSON.stringify(localSavedWords)
+        );
+      }
+      setLocalStorage();
+    },
+    [localSavedWords]
+  );
 
   function getFlashcards() {
     const flashcardsArray = localSavedWords.map((word) => ({
@@ -70,17 +74,17 @@ export default function DemoTextPage({ getText, updateText }) {
       pinyin: word.pinyin,
       meaning: word.meaning,
       id: word._id,
-    }))
-    setFlashcards(flashcardsArray)
+    }));
+    setFlashcards(flashcardsArray);
   }
-  
+
   function handleTabClick(tabName) {
-    setActiveTab(tabName)
+    setActiveTab(tabName);
   }
 
   async function favoriteText(text, textId) {
-    const updatedText = await textsAPI.favoriteText(text, textId)
-    updateText(updatedText)
+    const updatedText = await textsAPI.favoriteText(text, textId);
+    updateText(updatedText);
   }
 
   // async function saveWord(word, textId) {
@@ -90,41 +94,38 @@ export default function DemoTextPage({ getText, updateText }) {
   //   setShowPopup(false)
   // }
 
-  function generateID (wordToSave) {
-    const savedWords = JSON.parse(localStorage.getItem("stringifiedWords"))
-    if (savedWords.length === 0)
-      return 0
-    else
-      return savedWords[savedWords.length - 1]._id + 1
+  function generateID(wordToSave) {
+    const savedWords = JSON.parse(localStorage.getItem("stringifiedWords"));
+    if (savedWords.length === 0) return 0;
+    else return savedWords[savedWords.length - 1]._id + 1;
   }
 
   function saveWord(word) {
-    const savedWords = JSON.parse(localStorage.getItem("stringifiedWords"))
-    const wordToSave = getWordInfo(word)
-    wordToSave._id = generateID(wordToSave)
-    setLocalSavedWords([...savedWords, wordToSave])
-    setActiveWord('')
-    setShowPopup(false)
+    const savedWords = JSON.parse(localStorage.getItem("stringifiedWords"));
+    const wordToSave = getWordInfo(word);
+    wordToSave._id = generateID(wordToSave);
+    setLocalSavedWords([...savedWords, wordToSave]);
+    setActiveWord("");
+    setShowPopup(false);
   }
 
   // async function updateMeaning(word, formData) {
   //   const updatedWord = await wordsAPI.updateMeaning(word, formData)
-  //   setSavedWords(prevSavedWords => 
+  //   setSavedWords(prevSavedWords =>
   //     prevSavedWords.map(savedWord =>
   //       savedWord._id === updatedWord._id ? updatedWord : savedWord))
   // }
 
-  function updateMeaning(word, formData){
-    const savedWords = JSON.parse(localStorage.getItem("stringifiedWords"))
-    for (let k in savedWords){
-      if (savedWords[k]._id === word._id)
-        savedWords[k].meaning = formData
+  function updateMeaning(word, formData) {
+    const savedWords = JSON.parse(localStorage.getItem("stringifiedWords"));
+    for (let k in savedWords) {
+      if (savedWords[k]._id === word._id) savedWords[k].meaning = formData;
     }
-    setLocalSavedWords([...savedWords])
+    setLocalSavedWords([...savedWords]);
   }
 
   // async function deleteWord(word) {
-  //   setSavedWords(prevSavedWords => 
+  //   setSavedWords(prevSavedWords =>
   //     prevSavedWords.filter(savedWord => savedWord._id !== word._id))
   //     try {
   //       await wordsAPI.deleteWord(word)
@@ -134,38 +135,41 @@ export default function DemoTextPage({ getText, updateText }) {
   // }
 
   function deleteWord(word) {
-    const savedWords = JSON.parse(localStorage.getItem("stringifiedWords"))
-    const filteredWords = savedWords.filter((item) => item._id !== word._id)
-    setLocalSavedWords([...filteredWords])
+    const savedWords = JSON.parse(localStorage.getItem("stringifiedWords"));
+    const filteredWords = savedWords.filter((item) => item._id !== word._id);
+    setLocalSavedWords([...filteredWords]);
   }
 
   function handleOpen() {
-    setOpen(true)
-    getFlashcards()
+    setOpen(true);
+    getFlashcards();
   }
 
   function handleClose() {
-    setFlashcards([])
-    setCorrectCount(0)
-    setGameInProgress(false)
-    setOpen(false)
+    setFlashcards([]);
+    setCorrectCount(0);
+    setGameInProgress(false);
+    setOpen(false);
   }
 
   function handleCorrect() {
     // if the user marks the word correct, create a new array of flashcards removing the 1st one in the array (the one that was correct)
-    setFlashcards((prevFlashcards) => prevFlashcards.slice(1))
-    setCorrectCount(correctCount + 1)
-    setRemainingCount(remainingCount - 1)
+    setFlashcards((prevFlashcards) => prevFlashcards.slice(1));
+    setCorrectCount(correctCount + 1);
+    setRemainingCount(remainingCount - 1);
   }
 
   function handleIncorrect() {
     // if the user marks the word incorrect, create a new array by removing the 1st card (same as when you get it correct), but instead add it back in at the end of the new array (basically cycles the cards thru)
-    setFlashcards((prevFlashcards) => [...prevFlashcards.slice(1), prevFlashcards[0]])
+    setFlashcards((prevFlashcards) => [
+      ...prevFlashcards.slice(1),
+      prevFlashcards[0],
+    ]);
   }
 
   function handlePlay() {
-    setRemainingCount(flashcards.length)
-    setGameInProgress(true)
+    setRemainingCount(flashcards.length);
+    setGameInProgress(true);
   }
 
   function handlePlayAgain() {
@@ -174,26 +178,49 @@ export default function DemoTextPage({ getText, updateText }) {
       pinyin: word.pinyin,
       meaning: word.meaning,
       id: word._id,
-    }))
-    setFlashcards(flashcardsArray)
-    setGameInProgress(false)
-    setOpen(true)
+    }));
+    setFlashcards(flashcardsArray);
+    setGameInProgress(false);
+    setOpen(true);
   }
 
-  return !text ? 'Loading ...' 
-    : (
-    
-    <main className={`TextPage page ${expandedSidebar ? 'expanded-sidebar' : 'collapsed-sidebar'}`}>
+  //state that will be used to determine which sidebar to present based on which sidebar is clicked.
+  const [sidebarCategory, setSidebarCategory] = useState(null);
 
+  function changeSidebarCategory(selectedIcon) {
+    console.log("changesidebarcat ", selectedIcon);
+    console.log("pre-change category:", sidebarCategory);
+    if (sidebarCategory === selectedIcon) {
+      setSidebarCategory(null);
+    } else {
+      setSidebarCategory(selectedIcon);
+    }
+  }
+
+  function expandSidebar() {
+    setExpandedSidebar(!expandedSidebar);
+  }
+
+  return !text ? (
+    "Loading ..."
+  ) : (
+    <main
+      className={`TextPage page ${
+        expandedSidebar ? "expanded-sidebar" : "collapsed-sidebar"
+      }`}
+    >
       <nav className="side-nav">
-        <DemoNav 
+        <DemoNav
           expandSidebar={expandSidebar}
+          changeSidebarCategory={changeSidebarCategory}
+          sidebarCategory={sidebarCategory}
         />
       </nav>
-      
-      {expandedSidebar && (
+
+      {/* NOTE TO SELF: re-create this code so that there is some conditional rendering regarding which sidebar is displayed depending on what is clicked */}
+      {/* {expandedSidebar && (
         <aside className="sidebar">
-          <DemoSavedWordsList 
+          <DemoSavedWordsList
             savedWords={localSavedWords}
             updateMeaning={updateMeaning}
             deleteWord={deleteWord}
@@ -201,71 +228,106 @@ export default function DemoTextPage({ getText, updateText }) {
             gameInProgress={gameInProgress}
           />
         </aside>
+      )} */}
+
+      {expandedSidebar && (
+        <aside className="sidebar">
+          {sidebarCategory === "savedwords-tooltip" && (
+            <DemoSavedWordsList
+              savedWords={localSavedWords}
+              updateMeaning={updateMeaning}
+              deleteWord={deleteWord}
+              handleOpen={handleOpen}
+              gameInProgress={gameInProgress}
+            />
+          )}
+          {sidebarCategory === "flashcards-tooltip" && <h1>Learn</h1>}
+        </aside>
       )}
 
       <Dialog
-          open={open}
-          onClose={handleClose}   
-          PaperComponent={({ children }) => (
-            <div style={{ 
-              width: '60vmin', 
-              height: '50vmin',
-              backgroundColor: 'white',
-              color: 'var(--drk-txt)',
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              padding: '1vmin',
-              borderRadius: '2vmin'
-              }}>
-              {children}
-            </div>
-          )}
+        open={open}
+        onClose={handleClose}
+        PaperComponent={({ children }) => (
+          <div
+            style={{
+              width: "60vmin",
+              height: "50vmin",
+              backgroundColor: "white",
+              color: "var(--drk-txt)",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              padding: "1vmin",
+              borderRadius: "2vmin",
+            }}
+          >
+            {children}
+          </div>
+        )}
+      >
+        <DialogActions
+          style={{
+            alignSelf: "flex-end",
+            padding: "0",
+          }}
         >
-        <DialogActions style={{ 
-          alignSelf: 'flex-end',
-          padding: '0'
-          }}>
-          <Button
-          onClick={handleClose}>
-            <FaRegWindowClose className="close-icon"/>
+          <Button onClick={handleClose}>
+            <FaRegWindowClose className="close-icon" />
           </Button>
         </DialogActions>
         <DialogContent
-          style={{ 
-            width: '75%',
-            display: 'flex',
-            flexDirection: 'column',
-            justifyContent: 'space-between',
-            }}
-          >
-            { flashcards.length > 0 ? (
-              <>
-              { gameInProgress ? (
+          style={{
+            width: "75%",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "space-between",
+          }}
+        >
+          {flashcards.length > 0 ? (
+            <>
+              {gameInProgress ? (
                 <>
-                <DemoFlashcard 
-                chinese={flashcards[0].chinese}
-                pinyin={flashcards[0].pinyin}
-                english={flashcards[0].meaning}
-                selectedFront={selectedFront}
-                showPinyin={showPinyin}
-                onCorrect={handleCorrect}
-                onIncorrect={handleIncorrect}
-                flashcards={flashcards}
-                />
-                <div>
-                  <div className="flashcard-btns">
-                    <button className="correct-btn" onClick={handleCorrect}><GiCheckMark className="flashcard-icon" />Correct!</button>
-                    <button className="incorrect-btn"  onClick={handleIncorrect}><PiRepeatBold className="flashcard-icon" />Try again</button>
+                  <DemoFlashcard
+                    chinese={flashcards[0].chinese}
+                    pinyin={flashcards[0].pinyin}
+                    english={flashcards[0].meaning}
+                    selectedFront={selectedFront}
+                    showPinyin={showPinyin}
+                    onCorrect={handleCorrect}
+                    onIncorrect={handleIncorrect}
+                    flashcards={flashcards}
+                  />
+                  <div>
+                    <div className="flashcard-btns">
+                      <button className="correct-btn" onClick={handleCorrect}>
+                        <GiCheckMark className="flashcard-icon" />
+                        Correct!
+                      </button>
+                      <button
+                        className="incorrect-btn"
+                        onClick={handleIncorrect}
+                      >
+                        <PiRepeatBold className="flashcard-icon" />
+                        Try again
+                      </button>
+                    </div>
+                    <div className="flashcard-count">
+                      <p>
+                        <span className="correct-count">{correctCount}</span>{" "}
+                        Correct
+                      </p>
+                      <p>
+                        <span className="remaining-count">
+                          {remainingCount}
+                        </span>{" "}
+                        Remaining
+                      </p>
+                    </div>
                   </div>
-                  <div className="flashcard-count">
-                    <p><span className="correct-count">{correctCount}</span> Correct</p>
-                    <p><span className="remaining-count">{remainingCount}</span> Remaining</p>
-                  </div>
-                </div>
-              </>
+                </>
               ) : (
-                <DemoFlashcardForm 
+                <DemoFlashcardForm
                   selectedFront={selectedFront}
                   setSelectedFront={setSelectedFront}
                   showPinyin={showPinyin}
@@ -273,79 +335,103 @@ export default function DemoTextPage({ getText, updateText }) {
                   handlePlay={handlePlay}
                 />
               )}
-              </>
-              
-            ) : (
-              <div className="congrats">
-                <div>
-                  <dotlottie-player
+            </>
+          ) : (
+            <div className="congrats">
+              <div>
+                <dotlottie-player
                   src="https://lottie.host/9279b8f8-2d84-4077-aaf6-db967f8ec7bb/3JRYmBPJgq.json"
                   background="transparent"
                   speed="1"
-                  style={{ height: '20vmin' }}
+                  style={{ height: "20vmin" }}
                   loop
                   autoplay
                 ></dotlottie-player>
-                </div>
-                <h2>You completed the deck!</h2>
-                <button className="play-btn" onClick={handlePlayAgain}>Play Again</button>
               </div>
-            ) }
+              <h2>You completed the deck!</h2>
+              <button className="play-btn" onClick={handlePlayAgain}>
+                Play Again
+              </button>
+            </div>
+          )}
         </DialogContent>
       </Dialog>
 
       <section className="main-area">
-
         <div className="tabs">
-          <button className={`tab-btn ${activeTab === 'read' ? 'active' : ''}`} onClick={() => handleTabClick('read')} >Read</button>
-          <button className={`tab-btn ${activeTab === 'study' ? 'active' : ''}`} onClick={() => handleTabClick('study')} >Study</button>
-          <button className={`tab-btn ${activeTab === 'translate' ? 'active' : ''}`} onClick={() => handleTabClick('translate')} >Translate</button>
+          <button
+            className={`tab-btn ${activeTab === "read" ? "active" : ""}`}
+            onClick={() => handleTabClick("read")}
+          >
+            Read
+          </button>
+          <button
+            className={`tab-btn ${activeTab === "study" ? "active" : ""}`}
+            onClick={() => handleTabClick("study")}
+          >
+            Study
+          </button>
+          <button
+            className={`tab-btn ${activeTab === "translate" ? "active" : ""}`}
+            onClick={() => handleTabClick("translate")}
+          >
+            Translate
+          </button>
         </div>
 
-          <div className="text-area">
-            <div className='textpage-heading'>
-              <div className="flex-row">
-                <h1 className='textpage-heading-title zh'>{text.title}</h1>       
-              </div>
+        <div className="text-area">
+          <div className="textpage-heading">
+            <div className="flex-row">
+              <h1 className="textpage-heading-title zh">{text.title}</h1>
             </div>
-
-            <div id="study" className={`study-container ${activeTab === 'study' ? 'active' : ''}`}>
-              <div className="Text">
-                {text ? <DemoStudyText 
-                  text={text}
-                  textId={text._id} 
-                  activeWord={activeWord}
-                  setActiveWord={setActiveWord}
-                  saveWord={saveWord} 
-                  savedWords={localSavedWords} 
-                  setSavedWords={setSavedWords} 
-                  showPopup={showPopup}
-                  setShowPopup={setShowPopup}
-                  /> : 'Loading text'}
-              </div>
-            </div>
-
-            <div id="read" className={`read-container ${activeTab === 'read' ? 'active' : ''}`}>
-              <div className="Text">
-                {text ? <DemoReadText 
-                text={text}
-                /> : 'Loading text'}
-              </div>
-            </div>
-
-            <div id="translate" className={`translate-container ${activeTab === 'translate' ? 'active' : ''}`}>
-              <div className="Text">
-                {text ? <DemoTranslateText text={text} /> : 'Loading text'}
-              </div>
-            </div> 
-
-
           </div>
 
+          <div
+            id="study"
+            className={`study-container ${
+              activeTab === "study" ? "active" : ""
+            }`}
+          >
+            <div className="Text">
+              {text ? (
+                <DemoStudyText
+                  text={text}
+                  textId={text._id}
+                  activeWord={activeWord}
+                  setActiveWord={setActiveWord}
+                  saveWord={saveWord}
+                  savedWords={localSavedWords}
+                  setSavedWords={setSavedWords}
+                  showPopup={showPopup}
+                  setShowPopup={setShowPopup}
+                />
+              ) : (
+                "Loading text"
+              )}
+            </div>
+          </div>
+
+          <div
+            id="read"
+            className={`read-container ${activeTab === "read" ? "active" : ""}`}
+          >
+            <div className="Text">
+              {text ? <DemoReadText text={text} /> : "Loading text"}
+            </div>
+          </div>
+
+          <div
+            id="translate"
+            className={`translate-container ${
+              activeTab === "translate" ? "active" : ""
+            }`}
+          >
+            <div className="Text">
+              {text ? <DemoTranslateText text={text} /> : "Loading text"}
+            </div>
+          </div>
+        </div>
       </section>
-
-          
-
     </main>
-  )
+  );
 }


### PR DESCRIPTION
I created the sidebar that will display the demoflashcard activity form when you click on the appropriate button on the navBar. Moreover, I enabled it so that you can easily toggle the content in the sidebar in case you click on the "saved words" button while the sidebar is already present. I also created the "arrow back" button as requested for this issue. Lastly, I altered styling to more closely resemble the wireframe that was displayed. (I hard coded the colors. Let me know if you want me to add the colors to the CSS root!)

Note: I pushed additional commits up since I was working on another issue, but didn't realize it may have tacked onto this pull request. The additional commits reflect completion of "Improve UI for Saved Words issue". In that, I was able to closely match the new wireframe that was proposed in the issue. For the edit/delete tooltip menu, I made it also so that the menu fades out when the mouse exits the menu or the saved word card associated with the menu. I commented out a lot of code the wasn't needed anymore for the new UI. Lastly, I switched up the names of the "divs" in the saved words list to be more inclusive of semantic HTML elements for accessibility purposes. Let me know if you have any questions about anything!
