### PR TITLE
Restyle Tooltips

### DIFF
--- a/src/demo/demo-components/DemoNav/DemoNav.css
+++ b/src/demo/demo-components/DemoNav/DemoNav.css
@@ -5,6 +5,7 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  z-index: 10;
 }
 
 .placeholder-logo {
@@ -23,4 +24,10 @@
 .side-nav-icon-bottom:hover {
   background-color: var(--light);
   border-radius: .7vmin;
+}
+
+/* or teal-lt */
+.icon-tool-tip {
+  color: black !important;
+  background-color: #daf2ee !important;
 }

--- a/src/demo/demo-components/DemoNav/DemoNav.css
+++ b/src/demo/demo-components/DemoNav/DemoNav.css
@@ -26,8 +26,12 @@
   border-radius: .7vmin;
 }
 
-/* or teal-lt */
-.icon-tool-tip {
-  color: black !important;
-  background-color: #daf2ee !important;
+.icontip-container .icontip-message {
+  color: black;
+  background-color: var(--light);
+  padding: 8px 10px;
+  margin-left: 1.1%; /* best margin for now. this margin probs will need to be redone when sizing issue for demo page is resolved */
+  border-radius: 3px;
+  font-size: 90%;
+  width: max-content;
 }

--- a/src/demo/demo-components/DemoNav/DemoNav.jsx
+++ b/src/demo/demo-components/DemoNav/DemoNav.jsx
@@ -23,37 +23,42 @@ export default function DemoNav({ expandSidebar }) {
           data-tooltip-content="Saved Words" 
           data-tooltip-place="right" 
         />
-        <Tooltip id="savedwords-tooltip" />
+        <Tooltip id="savedwords-tooltip" className="icon-tool-tip"
+        border="1px solid #526662" />
         <MdQuiz 
           className="side-nav-icon-top" 
           data-tooltip-id="flashcards-tooltip" 
           data-tooltip-content="Flashcard Quiz" 
           data-tooltip-place="right" 
         />
-        <Tooltip id="flashcards-tooltip" />
+        <Tooltip id="flashcards-tooltip" className="icon-tool-tip"
+        border="1px solid #526662" />
         <FaArrowsRotate 
           className="side-nav-icon-top" 
           data-tooltip-id="changetext-tooltip" 
           data-tooltip-content="Change Text" 
           data-tooltip-place="right" 
         />
-        <Tooltip id="changetext-tooltip" />
+        <Tooltip id="changetext-tooltip" className="icon-tool-tip" 
+        border="1px solid #526662" />
       </div>
       <div className="bottom-icons">
         <FaRegQuestionCircle  
           className="side-nav-icon-bottom" 
           data-tooltip-id="support-tooltip" 
           data-tooltip-content="Support" 
-          data-tooltip-place="right" 
+          data-tooltip-place="right"
         />
-        <Tooltip id="support-tooltip" />
+        <Tooltip id="support-tooltip" className="icon-tool-tip" 
+        border="1px solid #526662" />
         <ImExit 
           className="side-nav-icon-bottom" 
           data-tooltip-id="exit-tooltip" 
           data-tooltip-content="Exit Demo" 
           data-tooltip-place="right" 
         />
-        <Tooltip id="exit-tooltip" />
+        <Tooltip id="exit-tooltip" className="icon-tool-tip" 
+        border="1px solid #526662"/>
       </div>
     </>
   )

--- a/src/demo/demo-components/DemoNav/DemoNav.jsx
+++ b/src/demo/demo-components/DemoNav/DemoNav.jsx
@@ -14,52 +14,93 @@ export default function DemoNav({ expandSidebar }) {
 
   return (
     <>
-      <div className='top-icons'>
-        <img src="/images/placeholder-logo.png" alt="logo" className="placeholder-logo" />
-        <TbCardsFilled 
-          className="side-nav-icon-top" 
-          onClick={handleCardsClick} 
-          data-tooltip-id="savedwords-tooltip" 
-          data-tooltip-content="Saved Words" 
-          data-tooltip-place="right" 
+      {/* Sidebar Icons */}
+      <div className="top-icons">
+        <img
+          src="/images/placeholder-logo.png"
+          alt="logo"
+          className="placeholder-logo"
         />
-        <Tooltip id="savedwords-tooltip" className="icon-tool-tip"
-        border="1px solid #526662" />
-        <MdQuiz 
-          className="side-nav-icon-top" 
-          data-tooltip-id="flashcards-tooltip" 
-          data-tooltip-content="Flashcard Quiz" 
-          data-tooltip-place="right" 
-        />
-        <Tooltip id="flashcards-tooltip" className="icon-tool-tip"
-        border="1px solid #526662" />
-        <FaArrowsRotate 
-          className="side-nav-icon-top" 
-          data-tooltip-id="changetext-tooltip" 
-          data-tooltip-content="Change Text" 
-          data-tooltip-place="right" 
-        />
-        <Tooltip id="changetext-tooltip" className="icon-tool-tip" 
-        border="1px solid #526662" />
+        {/* Saved Words Icon*/}
+        <div className="icontip-container">
+          <TbCardsFilled
+            className="side-nav-icon-top"
+            onClick={handleCardsClick}
+            data-tooltip-id="savedwords-tooltip"
+            data-tooltip-content="Saved Words"
+            data-tooltip-place="right"
+          />
+          <Tooltip
+            id="savedwords-tooltip"
+            className="icontip-message"
+            border="1px solid var(--medium)"
+            disableStyleInjection="true"
+          />
+        </div>
+        {/* Quiz Icon */}
+        <div className="icontip-container">
+          <MdQuiz
+            className="side-nav-icon-top"
+            data-tooltip-id="flashcards-tooltip"
+            data-tooltip-content="Flashcard Quiz"
+            data-tooltip-place="right"
+          />
+          <Tooltip
+            id="flashcards-tooltip"
+            className="icontip-message"
+            border="1px solid var(--medium)"
+            disableStyleInjection="true"
+          />
+        </div>
+        {/* Change Text Icon */}
+        <div className="icontip-container">
+          <FaArrowsRotate
+            className="side-nav-icon-top"
+            data-tooltip-id="changetext-tooltip"
+            data-tooltip-content="Change Text"
+            data-tooltip-place="right"
+            disableStyleInjection="true"
+          />
+          <Tooltip
+            id="changetext-tooltip"
+            className="icontip-message"
+            border="1px solid var(--medium)"
+            disableStyleInjection="true"
+          />
+        </div>
       </div>
       <div className="bottom-icons">
-        <FaRegQuestionCircle  
-          className="side-nav-icon-bottom" 
-          data-tooltip-id="support-tooltip" 
-          data-tooltip-content="Support" 
-          data-tooltip-place="right"
-        />
-        <Tooltip id="support-tooltip" className="icon-tool-tip" 
-        border="1px solid #526662" />
-        <ImExit 
-          className="side-nav-icon-bottom" 
-          data-tooltip-id="exit-tooltip" 
-          data-tooltip-content="Exit Demo" 
-          data-tooltip-place="right" 
-        />
-        <Tooltip id="exit-tooltip" className="icon-tool-tip" 
-        border="1px solid #526662"/>
+        {/* Support Icon */}
+        <div className="icontip-container">
+          <FaRegQuestionCircle
+            className="side-nav-icon-bottom"
+            data-tooltip-id="support-tooltip"
+            data-tooltip-content="Support"
+            data-tooltip-place="right"
+          />
+          <Tooltip
+            id="support-tooltip"
+            className="icontip-message"
+            border="1px solid var(--medium)"
+            disableStyleInjection="true"
+          />
+        </div>
+        {/* Exit Icon */}
+        <div className="icontip-container">
+          <ImExit
+            className="side-nav-icon-bottom"
+            data-tooltip-id="exit-tooltip"
+            data-tooltip-content="Exit Demo"
+            data-tooltip-place="right"
+          />
+          <Tooltip
+            id="exit-tooltip"
+            className="icontip-message"
+            border="1px solid var(--medium)"
+            disableStyleInjection="true"
+          />
+        </div>
       </div>
     </>
-  )
+  );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client'
 import './index.css'
 import App from './pages/App/App'
 import { BrowserRouter as Router } from 'react-router-dom'
-import 'react-tooltip/dist/react-tooltip.css'
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
Tooltips is restyled to use custom styling to match the theme of the website, while keeping the darker theme for readability.

Some notes:
- this was removed `import 'react-tooltip/dist/react-tooltip.css'`, since no longer using built-in styling from the library.
- Each tooltip icon is wrapped in a div for css specificity for custom styling, as suggested by the documentation.
- changing opacity affects hover animation. `delayShow={100}` helps keep it close to original animation