### PR TITLE
Fixed Popup box triangle & handleOutsideClick.

### DIFF
--- a/src/demo/demo-components/DemoPopup/DemoPopup.css
+++ b/src/demo/demo-components/DemoPopup/DemoPopup.css
@@ -11,6 +11,7 @@
   box-shadow: 0 0 5px rgba(0,0,0,0.2);
   min-width: 20%;
   overflow: visible;
+  z-index: 1;
 }
 
 .popup-content {
@@ -21,16 +22,18 @@
   bottom: 0;
 }
 
-.play-arrow-icon {
-  fill: #effffc !important; 
-  stroke: rgba(0,0,0,0.2);
-  stroke-width: 1;
-  stroke-dasharray: 12.5 100; 
-  stroke-dashoffset: -1; 
-  margin-bottom: -20px;
-  position: relative;
-  top: -4px;
-  transform: scaleX(0.6) scale(1.5);
+.popup-arrow {
+  position: absolute;
+  bottom: 0;
+  left: 20%;
+  margin-bottom: -5px;
+  margin-left: -10px;
+  background-color: #effffc;
+  transform: rotate( 45deg );
+  height: 15px;
+  width: 15px;
+  z-index: -1;
+  box-shadow: 2px 2px 2px 0 rgba( 178, 178, 178, .4 );
 }
 
 .popup-glyphs {

--- a/src/demo/demo-components/DemoPopup/DemoPopup.jsx
+++ b/src/demo/demo-components/DemoPopup/DemoPopup.jsx
@@ -1,62 +1,54 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import './DemoPopup.css'
 
-export default function Popup({ word, popupPosition, saveWord, textId, onClose}) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [popupHeight, setPopupHeight] = useState('15%'); 
+export default function Popup({ word, popupPosition, saveWord, textId, onClose }) {
+  const [popupHeight, setPopupHeight] = useState('15%');
+  const popupRef = useRef(null);
 
   useEffect(() => {
     const handleOutsideClick = (event) => {
-      if (!event.target.closest('.Popup') && isOpen) {
+      if (popupRef.current && !popupRef.current.contains(event.target)) {
         onClose();
-        setIsOpen(false);
       }
     };
-    document.addEventListener('click', handleOutsideClick);
+
+    document.addEventListener('mousedown', handleOutsideClick);
     return () => {
-      document.removeEventListener('click', handleOutsideClick);
-      setIsOpen(false); 
+      document.removeEventListener('mousedown', handleOutsideClick);
     };
   }, [onClose]);
-
-  let pinyin = ''
-  let meaning = ''
-
-  if (word.matches && word.matches[0]) {
-    pinyin = word.matches[0].pinyinPretty
-    meaning = word.matches[0].english
-    meaning = meaning.includes('/') ? meaning.split('/')[0].trim() : meaning
-
-  } else {
-    pinyin = ''
-    meaning = ''
-  }
-
-  function handleSaveClick(word) {
-    saveWord(word)
-  }
 
   useEffect(() => {
     const popupMeaning = document.querySelector('.popup-meaning');
     const html = popupMeaning.innerHTML;
     const lines = html.split('<br>').length; // count the number of lines by splitting on <br> elements
-    if (lines > 1) {
-      setPopupHeight('17%'); // update popup height to 17% if there are more than 1 line
-    } else {
-      setPopupHeight('15%'); // keep popup height to 15% if there is only 1 line
-    }
-  }, [meaning]);
+    setPopupHeight(lines > 1 ? '17%' : '15%'); // update popup height based on the number of lines
+  }, [word]);
+
+  let pinyin = '';
+  let meaning = '';
+
+  if (word.matches && word.matches[0]) {
+    pinyin = word.matches[0].pinyinPretty;
+    meaning = word.matches[0].english;
+    meaning = meaning.includes('/') ? meaning.split('/')[0].trim() : meaning;
+  }
+
+  function handleSaveClick() {
+    saveWord(word);
+  }
 
   return (
-      <div
-        className="Popup"
-        style={{
-          left: `${popupPosition[0] + 105}px`,
-          top: popupHeight === '15%'? `${popupPosition[1] - 10}px` : `${popupPosition[1] - 14}px`,
-          height: popupHeight,
-        }}
-      >
+    <div
+      className="Popup"
+      style={{
+        left: `${popupPosition[0] + 145}px`,
+        top: popupHeight === '15%' ? `${popupPosition[1] + 10}px` : `${popupPosition[1] - 0}px`,
+        height: popupHeight,
+      }}
+      ref={popupRef}
+    >
       <div className="popup-content">
         <p className="popup-pinyin">{pinyin}</p>
         <p className="popup-glyphs">{word.text}</p>
@@ -71,12 +63,9 @@ export default function Popup({ word, popupPosition, saveWord, textId, onClose})
           )}
         </p>
       </div>
-      <ArrowDropDownIcon className="play-arrow-icon" />
-      <button className="save-button" onClick={() => handleSaveClick(word)}> + </button> &nbsp; 
-      <button className="close-btn" onClick={() => {
-        onClose();
-        setIsOpen(false);
-      }}> x </button>
+      <button className="save-button" onClick={handleSaveClick}> + </button> &nbsp; 
+      <button className="close-btn" onClick={onClose}> x </button>
+      <div className="popup-arrow" />
     </div>
-  )
+  );
 }

--- a/src/demo/demo-components/DemoStudyText/DemoStudyText.jsx
+++ b/src/demo/demo-components/DemoStudyText/DemoStudyText.jsx
@@ -28,17 +28,23 @@ export default function DemoStudyText({ text, textId, activeWord, setActiveWord,
     if (showPopup) {
       setActiveWord('')
       setShowPopup(false)
-      return
+      // return
     }
   }
 
-  function handleWordClick(word, evt) {
-    if (showPopup) {
-      // Close the previous popup
-      setShowPopup(false);
-      setActiveWord('');
-    }
+  // function handleWordClick(word, evt) {
+  //   if (showPopup) {
+  //     // Close the previous popup
+  //     setShowPopup(false);
+  //     setActiveWord('');
+  //   }
     // Open the new popup
+  //   setActiveWord(word);
+  //   setPopupPosition([evt.pageX, evt.pageY]);
+  //   setShowPopup(true);
+  // }
+
+  function handleWordClick(word, evt) {
     setActiveWord(word);
     setPopupPosition([evt.pageX, evt.pageY]);
     setShowPopup(true);


### PR DESCRIPTION
User can now click outside the box and it will collapse, but also click seamlessly from one word to another without having to click 2 times. Instead of the fake triangle hack in CSS I created a square div with the same color as the Popup box and rotated it 45% to make it a triangle and then put a box shadow on it and used z-index to put it beneath the Popup box.

<sub><a href="https://huly.app/guest/knownative?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmFkMWIyMTNmNGI3OTE2NjM0YmIzN2MiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWJpZ2FpbGRhd3NvLWtub3duYXRpdmUtNjYzMjgxYjEtODdiZTE2ZDY5OS0yYTZiY2QiLCJwcm9kdWN0SWQiOiIifQ.-BuN__Og-taeGI8pr0rBxIuwc9WIOE6KJdwc2LWljSE">Huly&reg;: <b>GITHB-48</b></a></sub>