### PR TITLE
Fixing page resize bug (DEMO-31)

### DIFF
--- a/src/components/Sentence/Sentence.css
+++ b/src/components/Sentence/Sentence.css
@@ -11,11 +11,20 @@
 .show-translation {
   letter-spacing: 0;
   text-decoration: underline;
-  font-size: 2vmin;
+  font-size: 1.3rem;
 }
 
 .hide-translation:hover,
 .show-translation:hover {
   color: var(--red);
   cursor: pointer;
+}
+
+/* small screens and smaller */
+@media (max-width: 550px) { 
+  .hide-translation,
+  .show-translation {
+    font-size: 1rem;
+  }
+
 }

--- a/src/demo/demo-components/DemoNav/DemoNav.css
+++ b/src/demo/demo-components/DemoNav/DemoNav.css
@@ -1,6 +1,6 @@
 .top-icons,
 .bottom-icons {
-  padding: 1vmin 0;
+  padding: 5px 0;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -10,13 +10,13 @@
 
 .placeholder-logo {
   width: 80%;
-  margin-bottom: 3vmin;
+  margin-bottom: 30px;
 }
 .side-nav-icon-top,
 .side-nav-icon-bottom {
-  font-size: 6vmin;
+  font-size: 4.5rem;
   margin: 0;
-  padding: 1.3vmin;
+  padding: 1rem;
   color: var(--dark);
 }
 
@@ -34,4 +34,15 @@
   border-radius: 5px;
   font-size: 90%;
   width: max-content;
+}
+
+/* medium screens and smaller */
+@media (max-width: 768px) { 
+
+  .side-nav-icon-top,
+  .side-nav-icon-bottom {
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+
 }

--- a/src/demo/demo-components/DemoPopup/DemoPopup.css
+++ b/src/demo/demo-components/DemoPopup/DemoPopup.css
@@ -6,10 +6,10 @@
   padding: 1.75vmin 1.5vmin 0 1.5vmin;
   left: 50%; 
   top: 50%; 
-  margin-left: -10%; 
-  margin-top: -10%; 
+  margin-left: -100px; 
+  margin-top: -30px; 
   box-shadow: 0 0 5px rgba(0,0,0,0.2);
-  min-width: 20%;
+  min-width: 200px;
   overflow: visible;
 }
 
@@ -41,7 +41,7 @@
 
 .popup-pinyin,
 .popup-meaning {
-  font-size: 1.5vmin;
+  font-size: 0.9rem;
   color: var(--drk-txt);
 }
 
@@ -50,7 +50,7 @@
 }
 
 .close-btn {
-  font-size: 2.5vmin; 
+  font-size: 1.5rem; 
   font-family: 'roboto';
   font-family:'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
   background: none;
@@ -67,8 +67,8 @@
   background-color: #58bdaa;
   cursor: pointer;
   position: absolute;
-  width: 1vmin;
-  height: 2.25vmin;
+  width: 1.3rem;
+  height: 1.4rem;
   font-size: 2.5vmin; 
   border-radius: 60%;
   bottom: 0.8vmin;
@@ -77,4 +77,28 @@
   align-items: center;
   justify-content: center;
   color: white;
+}
+
+/* medium screens and smaller */
+@media (max-width: 768px) { 
+
+  .popup-glyphs {
+    font-size: 1.7rem;
+  }
+
+
+}
+
+/* small screens and smaller */
+@media (max-width: 550px) { 
+
+  .popup-glyphs {
+    font-size: 1.5rem;
+  }
+
+  .popup-pinyin,
+  .popup-meaning {
+    font-size: 0.8rem;
+  }
+  
 }

--- a/src/demo/demo-components/DemoPopup/DemoPopup.css
+++ b/src/demo/demo-components/DemoPopup/DemoPopup.css
@@ -34,7 +34,7 @@
 }
 
 .popup-glyphs {
-  font-size: 3vmin;
+  font-size: 2rem;
   color: black;
   font-weight: bold;
 }

--- a/src/demo/demo-components/DemoPopup/DemoPopup.jsx
+++ b/src/demo/demo-components/DemoPopup/DemoPopup.jsx
@@ -42,9 +42,9 @@ export default function Popup({ word, popupPosition, saveWord, textId, onClose})
     const html = popupMeaning.innerHTML;
     const lines = html.split('<br>').length; // count the number of lines by splitting on <br> elements
     if (lines > 1) {
-      setPopupHeight('17%'); // update popup height to 17% if there are more than 1 line
+      setPopupHeight('220px'); // update popup height to 220px if there are more than 1 line
     } else {
-      setPopupHeight('15%'); // keep popup height to 15% if there is only 1 line
+      setPopupHeight('190px'); // keep popup height to 190px if there is only 1 line
     }
   }, [meaning]);
 
@@ -53,8 +53,9 @@ export default function Popup({ word, popupPosition, saveWord, textId, onClose})
         className="Popup"
         style={{
           left: `${popupPosition[0] + 105}px`,
-          top: popupHeight === '15%'? `${popupPosition[1] - 10}px` : `${popupPosition[1] - 14}px`,
+          top: popupHeight === '11rem'? `${popupPosition[1] - 100}px` : `${popupPosition[1] - 50}px`,
           height: popupHeight,
+          
         }}
       >
       <div className="popup-content">

--- a/src/demo/demo-components/DemoReadText/DemoReadText.css
+++ b/src/demo/demo-components/DemoReadText/DemoReadText.css
@@ -31,9 +31,9 @@
 
 .read-text-block {
   margin-top: 2vmin;
-  line-height: 4vmin;
+  line-height: 40px;
   letter-spacing: .3vmin;
-  font-size: 2.5vmin;
+  font-size: 30px;
   text-align: left;
   white-space: pre;
   transition: grid-column 0.5s;

--- a/src/demo/demo-components/DemoReadText/DemoReadText.css
+++ b/src/demo/demo-components/DemoReadText/DemoReadText.css
@@ -31,12 +31,13 @@
 
 .read-text-block {
   margin-top: 2vmin;
-  line-height: 40px;
+  line-height: 55px;
   letter-spacing: .3vmin;
-  font-size: 30px;
+  font-size: 27px;
   text-align: left;
   white-space: pre;
   transition: grid-column 0.5s;
+  max-width: 900px;
 }
 
 .read-text-block > .zh {
@@ -211,4 +212,16 @@
   100% {
     transform: scale(1.02);
   }
+}
+
+/* medium screens and smaller */
+@media (max-width: 768px) { 
+
+  .read-text-block {
+    line-height: 40px;
+    letter-spacing: .3vmin;
+    font-size: 20px;
+    margin-left: 20px;
+  }
+
 }

--- a/src/demo/demo-components/DemoReadText/DemoReadText.css
+++ b/src/demo/demo-components/DemoReadText/DemoReadText.css
@@ -1,9 +1,8 @@
-.ReadText {
+.read-text {
   display: flex;
   flex-direction: column;
   grid-template-columns: 50% 50%;
   gap: 2vmin;
-  margin: 0 3vmin 0 3vmin;
   padding: 4vmin 2vmin;
   color: var(--drk-txt);
 }
@@ -31,9 +30,9 @@
 
 .read-text-block {
   margin-top: 2vmin;
-  line-height: 55px;
+  line-height: 45px;
   letter-spacing: .3vmin;
-  font-size: 27px;
+  font-size: 28px;
   text-align: left;
   white-space: pre;
   transition: grid-column 0.5s;
@@ -225,3 +224,12 @@
   }
 
 }
+
+/* small screens and smaller */
+@media (max-width: 550px) { 
+  .read-text {
+    padding: 4vmin 0 0 5vmin;
+  }
+
+}
+

--- a/src/demo/demo-components/DemoReadText/DemoReadText.css
+++ b/src/demo/demo-components/DemoReadText/DemoReadText.css
@@ -30,9 +30,9 @@
 
 .read-text-block {
   margin-top: 2vmin;
-  line-height: 45px;
+  line-height: 3.1rem;
   letter-spacing: .3vmin;
-  font-size: 28px;
+  font-size: 1.8rem;
   text-align: left;
   white-space: pre;
   transition: grid-column 0.5s;
@@ -217,9 +217,7 @@
 @media (max-width: 768px) { 
 
   .read-text-block {
-    line-height: 40px;
-    letter-spacing: .3vmin;
-    font-size: 20px;
+    font-size: 1.3rem;
     margin-left: 20px;
   }
 

--- a/src/demo/demo-components/DemoReadText/DemoReadText.jsx
+++ b/src/demo/demo-components/DemoReadText/DemoReadText.jsx
@@ -5,7 +5,7 @@ export default function DemoReadText({ text }) {
   
   return !text ? 'Loading ...' 
   : (    
-  <div className="ReadText">
+  <div className="read-text">
 
     <div className="bottom">
       <div className="read-text-block">

--- a/src/demo/demo-components/DemoStudyText/DemoStudyText.css
+++ b/src/demo/demo-components/DemoStudyText/DemoStudyText.css
@@ -1,10 +1,11 @@
 .StudyText {
   display: flex;
   flex-direction: column;
-  gap: 2vmin;
+  gap: 2rem;
   margin: 0 3vmin 0 3vmin;
   padding: 4vmin 2vmin;
   color: var(--drk-txt);
+  max-width: 900px;
 }
 
 .study-text-block {
@@ -13,4 +14,17 @@
   flex-wrap: wrap;
   align-items: flex-start;
   padding-top: 4vmin;
+}
+
+
+/* small screens and smaller */
+@media (max-width: 550px) { 
+  .TranslateText {
+    padding: 4vmin 0 0 5.5vmin;
+  }
+
+  .study-text-block {
+    margin-left: 20px
+  }
+
 }

--- a/src/demo/demo-components/DemoStudyText/DemoStudyText.css
+++ b/src/demo/demo-components/DemoStudyText/DemoStudyText.css
@@ -1,6 +1,7 @@
 .StudyText {
   display: flex;
   flex-direction: column;
+  position: relative;
   gap: 2rem;
   margin: 0 3vmin 0 3vmin;
   padding: 4vmin 2vmin;

--- a/src/demo/demo-components/DemoStudyText/DemoStudyText.jsx
+++ b/src/demo/demo-components/DemoStudyText/DemoStudyText.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import './DemoStudyText.css'
 import DemoPopup from '../DemoPopup/DemoPopup'
 import DemoWord from '../DemoWord/DemoWord'
@@ -9,6 +9,8 @@ export default function DemoStudyText({ text, textId, activeWord, setActiveWord,
 
   const [tokenizedText, setTokenizedText] = useState([])
   const [popupPosition, setPopupPosition] = useState([0,0])
+  const containerRef = useRef(null);
+
 
   useEffect(function() {
     async function getTokenizedText() {
@@ -40,7 +42,15 @@ export default function DemoStudyText({ text, textId, activeWord, setActiveWord,
     }
     // Open the new popup
     setActiveWord(word);
-    setPopupPosition([evt.pageX, evt.pageY]);
+    
+    // Note: using containerRect here so popup is positioned relative to the containerRef. 
+    // changed from pageX (whole document) to clientX (just the current viewport)
+    const containerRect = containerRef.current.getBoundingClientRect();
+    
+    setPopupPosition([
+      evt.clientX - containerRect.left, 
+      evt.clientY - containerRect.top - 40
+    ]);
     setShowPopup(true);
   }
 
@@ -79,7 +89,7 @@ export default function DemoStudyText({ text, textId, activeWord, setActiveWord,
 
   return (
     <>
-      <div className="StudyText">
+      <div className="StudyText" ref={containerRef}>
         <div className="study-text-block">
           {words}
         </div>

--- a/src/demo/demo-components/DemoTranslateText/DemoTranslateText.css
+++ b/src/demo/demo-components/DemoTranslateText/DemoTranslateText.css
@@ -9,7 +9,7 @@
 
 .translate-text-block {
   margin-top: 2vmin;
-  line-height: 3.5vmin;
-  font-size: 2.5vmin;
+  line-height: 40px;
+  font-size: 30px;
   text-align: left;
 }

--- a/src/demo/demo-components/DemoTranslateText/DemoTranslateText.css
+++ b/src/demo/demo-components/DemoTranslateText/DemoTranslateText.css
@@ -19,7 +19,7 @@
 @media (max-width: 768px) { 
 
   .translate-text-block {
-    font-size: 1.4rem;
+    font-size: 1.3rem;
   }
 
 }

--- a/src/demo/demo-components/DemoTranslateText/DemoTranslateText.css
+++ b/src/demo/demo-components/DemoTranslateText/DemoTranslateText.css
@@ -9,7 +9,25 @@
 
 .translate-text-block {
   margin-top: 2vmin;
-  line-height: 40px;
-  font-size: 30px;
+  line-height: 3.1rem;
+  font-size: 1.8rem;
   text-align: left;
+  max-width: 900px;
+}
+
+/* medium screens and smaller */
+@media (max-width: 768px) { 
+
+  .translate-text-block {
+    font-size: 1.4rem;
+  }
+
+}
+
+/* small screens and smaller */
+@media (max-width: 550px) { 
+  .TranslateText {
+    padding: 4vmin 0 0 5.5vmin;
+  }
+
 }

--- a/src/demo/demo-components/DemoTranslation/DemoTranslation.css
+++ b/src/demo/demo-components/DemoTranslation/DemoTranslation.css
@@ -1,6 +1,14 @@
 .translation {
   letter-spacing: 0;
-  font-size: 21px;
+  font-size: 1.2rem;
   margin: 1vmin 0 4vmin 0;
   color: var(--red)
+}
+
+/* small screens and smaller */
+@media (max-width: 550px) { 
+  .translation {
+    font-size: 1rem;
+  }
+
 }

--- a/src/demo/demo-components/DemoTranslation/DemoTranslation.css
+++ b/src/demo/demo-components/DemoTranslation/DemoTranslation.css
@@ -1,6 +1,6 @@
 .translation {
   letter-spacing: 0;
-  font-size: 2vmin;
+  font-size: 21px;
   margin: 1vmin 0 4vmin 0;
   color: var(--red)
 }

--- a/src/demo/demo-components/DemoWord/DemoWord.css
+++ b/src/demo/demo-components/DemoWord/DemoWord.css
@@ -6,10 +6,10 @@
 .specialChar {
   display: flex;
   flex-direction: column;
-  height: 9vmin;
-  max-width: 10vmin;
+  height: 6.05rem;
+  max-width: 6.7rem;
   margin: 0 .5vmin;
-  font-size: 2.5vmin;
+  font-size: 1.5rem;
   text-wrap: wrap;
 }
 
@@ -23,10 +23,10 @@
 }
 
 .annotation {
-  height: 6vmin;
+  height: 3.3rem;
   text-wrap: wrap;
   text-align: center;
-  font-size: 1.3vmin;
+  font-size: 0.85rem;
   color: var(--drk-txt);
 }
 
@@ -35,4 +35,18 @@
   border-radius: 0.5vmin;
   padding: 2px;
   opacity: 0.8;
+}
+
+/* medium screens and smaller */
+@media (max-width: 768px) { 
+
+  .Word,
+  .specialChar {
+    font-size: 1.3rem;
+  }
+
+  .annotation {
+    font-size: 0.8rem;
+  }
+
 }

--- a/src/demo/demo-pages/DemoTextPage/DemoTextPage.css
+++ b/src/demo/demo-pages/DemoTextPage/DemoTextPage.css
@@ -10,7 +10,7 @@
   justify-content: center;
 }
 .textpage-heading-title {
-  font-size: 4vmin;
+  font-size: 43px;
   display: inline-block;
 }
 

--- a/src/demo/demo-pages/DemoTextPage/DemoTextPage.css
+++ b/src/demo/demo-pages/DemoTextPage/DemoTextPage.css
@@ -1,8 +1,11 @@
 .textpage-heading {
   display: flex;
+  max-width: 900px;
+  text-align: left;
+  width: 100%;
   flex-direction: column;
   margin: 0 3vmin 0 3vmin;
-  padding: 4vmin 2vmin 0 2vmin;
+  padding: 4vmin 0 0 2vmin;
   color: var(--darkest);
 }
 
@@ -15,10 +18,12 @@
 }
 
 .text-area {
-  border-radius: 2vmin;
   background: white;
   padding: 2vmin;
   height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .read-container,
@@ -112,4 +117,12 @@
     font-size: 28px;
     margin-left: 20px;
   }
+}
+
+/* small screens and smaller */
+@media (max-width: 550px) { 
+  .textpage-heading {
+    padding: 4vmin 0 0 5vmin;
+  }
+
 }

--- a/src/demo/demo-pages/DemoTextPage/DemoTextPage.css
+++ b/src/demo/demo-pages/DemoTextPage/DemoTextPage.css
@@ -103,3 +103,13 @@
   background-color: var(--teal-lt);
   transform: scale(1.1);
 }
+
+
+/* medium screens and smaller */
+@media (max-width: 768px) { 
+
+  .textpage-heading-title {
+    font-size: 28px;
+    margin-left: 20px;
+  }
+}

--- a/src/demo/demo-pages/DemoTextPage/DemoTextPage.css
+++ b/src/demo/demo-pages/DemoTextPage/DemoTextPage.css
@@ -4,8 +4,7 @@
   text-align: left;
   width: 100%;
   flex-direction: column;
-  margin: 0 3vmin 0 3vmin;
-  padding: 4vmin 0 0 2vmin;
+  margin: 0 3vmin 0 0;
   color: var(--darkest);
 }
 
@@ -13,7 +12,7 @@
   justify-content: center;
 }
 .textpage-heading-title {
-  font-size: 43px;
+  font-size: 2.7rem;
   display: inline-block;
 }
 
@@ -109,12 +108,19 @@
   transform: scale(1.1);
 }
 
+/* xl screens and smaller */
+@media (max-width:  1280px) {
+  .textpage-heading-title {
+    padding: 4vmin 0 0 2vmin;
+  }
+}
 
 /* medium screens and smaller */
 @media (max-width: 768px) { 
 
   .textpage-heading-title {
-    font-size: 28px;
+    padding: 4vmin 0 0 2vmin;
+    font-size: 1.75rem;
     margin-left: 20px;
   }
 }

--- a/src/demo/demo-pages/DemoTextPage/DemoTextPage.css
+++ b/src/demo/demo-pages/DemoTextPage/DemoTextPage.css
@@ -32,6 +32,10 @@
   
 }
 
+.study-content {
+  position: relative;
+}
+
 .read-container.active,
 .study-container.active,
 .translate-container.active {

--- a/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
+++ b/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
@@ -403,7 +403,7 @@ export default function DemoTextPage({ getText, updateText }) {
               activeTab === "study" ? "active" : ""
             }`}
           >
-            <div className="Text">
+            <div className="Text study-content">
               {text ? (
                 <DemoStudyText
                   text={text}

--- a/src/index.css
+++ b/src/index.css
@@ -218,3 +218,13 @@ a {
   }
 
 }
+
+
+/* xsmall screens and smaller */
+@media (max-width: 400px) { 
+
+  .tab-btn {
+    font-size: 1.1rem;
+  }
+
+}

--- a/src/index.css
+++ b/src/index.css
@@ -194,7 +194,7 @@ a {
   margin: 1vmin 0 3vmin 0;
   border-radius: 1vmin;
   padding: .5vmin 2vmin;
-  font-size: 2vmin;
+  font-size: 22px;
   background-color: var(--white);
   color: var(--dark);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -149,6 +149,7 @@ a {
   background: white;
   padding: 3vmin;
   height: 100vh;
+  overflow-y: auto; /* Enable vertical scrolling if content overflows */ 
 }
 
 .page.collapsed-sidebar .sidebar {
@@ -167,6 +168,7 @@ a {
   padding: 0;
   background-color: var(--lightest);
   border-right: 1px solid var(--medium);
+  z-index: 5;
 }
 
 .sidebar {
@@ -204,4 +206,14 @@ a {
 
 .zh {
   font-family: 'Noto Serif TC', serif;
+}
+
+/* medium screens and smaller */
+@media (max-width: 768px) { 
+
+  .side-nav {
+    height: 100vh;
+    width: 65px;
+  }
+
 }

--- a/src/index.css
+++ b/src/index.css
@@ -165,6 +165,7 @@ a {
   align-items: center;
   background-color: green;
   height: 100vh;
+  width: 90px;
   padding: 0;
   background-color: var(--lightest);
   border-right: 1px solid var(--medium);
@@ -194,7 +195,7 @@ a {
   margin: 1vmin 0 3vmin 0;
   border-radius: 1vmin;
   padding: .5vmin 2vmin;
-  font-size: 22px;
+  font-size: 1.4rem;
   background-color: var(--white);
   color: var(--dark);
 }


### PR DESCRIPTION
This fixes the issue where text would resize too small when screen width became smaller. 
The main issue was `vmin` units were used for font-size. I decided to replace the `vmin` units for text sizes to `rem`, since `rem` was better for accesibility (uses user browser settings for example, if they need larger text).

Notes:
- since `rem` does not shrink when screen size gets smaller, I added media queries only where necessary, mainly used for the text size (I understand these could change when UX has mobile designs ready!)
- added a `max-width` of 900px on each tab container, so the text doesn't over extend
- switching from `vmin` units to `rem` units and applying `max-width` for the study tab text broke how the pop up was positioned. I added a `containerRef` to the text container so that the pop up only moved in relation to the text container, not the viewport. 
- I left `vmin` for elements that did not affect how it looked when screen resized, such as `padding` and some `margins`.

Please let me know if you'd like to see something different with this task, any questions about the code, or if anything needs changing!