### PR TITLE
add github url to landing page nav bar

### DIFF
--- a/src/components/LandingPageNav/LandingPageNav.jsx
+++ b/src/components/LandingPageNav/LandingPageNav.jsx
@@ -9,7 +9,7 @@ export default function LandingPageNav() {
             <ul class="navbar-nav ms-auto my-2 my-lg-0">
               <li class="nav-item"><a class="nav-link" href="/">About</a></li>
               <li class="nav-item"><Link class="nav-link" to="/contact">Contact</Link></li>
-              <li class="nav-item"><a class="nav-link" href="https://github.com/AbigailDawson/knownative">GitHub</a></li>
+              <li class="nav-item"><a class="nav-link" href="https://github.com/AbigailDawson/knownative" target="_blank" rel="noreferrer">GitHub</a></li>
             </ul>
           </div>
       </div>

--- a/src/components/LandingPageNav/LandingPageNav.jsx
+++ b/src/components/LandingPageNav/LandingPageNav.jsx
@@ -9,7 +9,7 @@ export default function LandingPageNav() {
             <ul class="navbar-nav ms-auto my-2 my-lg-0">
               <li class="nav-item"><a class="nav-link" href="/">About</a></li>
               <li class="nav-item"><Link class="nav-link" to="/contact">Contact</Link></li>
-              <li class="nav-item"><a class="nav-link" href="/">GitHub</a></li>
+              <li class="nav-item"><a class="nav-link" href="https://github.com/AbigailDawson/knownative">GitHub</a></li>
             </ul>
           </div>
       </div>


### PR DESCRIPTION
Href change to line 12 of LandingPageNav.jsx to navigate to Github repo

<sub><a href="https://huly.app/guest/knownative?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmIyMzA3MzMxNzgzMzIwZjc3ZTc1YWYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWJpZ2FpbGRhd3NvLWtub3duYXRpdmUtNjYzMjgxYjEtODdiZTE2ZDY5OS0yYTZiY2QiLCJwcm9kdWN0SWQiOiIifQ.YnT2w4KG8jngP_enFXMeCHAD7w94vRd0Op3hk3dS8t0">Huly&reg;: <b>GITHB-51</b></a></sub>