### PR TITLE
Hotfix for disableStyleInjection console error

### DIFF
--- a/src/demo/demo-components/DemoNav/DemoNav.jsx
+++ b/src/demo/demo-components/DemoNav/DemoNav.jsx
@@ -83,7 +83,6 @@ export default function DemoNav({
             data-tooltip-id="changetext-tooltip"
             data-tooltip-content="Change Text"
             data-tooltip-place="right"
-            disableStyleInjection="true"
           />
           <Tooltip
             id="changetext-tooltip"
@@ -100,7 +99,6 @@ export default function DemoNav({
             data-tooltip-id="info-tooltip"
             data-tooltip-content="Info"
             data-tooltip-place="right"
-            disableStyleInjection="true"
           />
           <Tooltip
             id="info-tooltip"


### PR DESCRIPTION
This fixes the error disableStyleInjection being on a react element. It was on a react element instead of a tooltip

<sub><a href="https://huly.app/guest/knownative?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmI0YWQzYjljODhlY2NiNTBmYTVlYjEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWJpZ2FpbGRhd3NvLWtub3duYXRpdmUtNjYzMjgxYjEtODdiZTE2ZDY5OS0yYTZiY2QiLCJwcm9kdWN0SWQiOiIifQ.qjPAi1jhCkNgBWCQ0xhLBBd-vwWeKwPTb4gvuPuRCVk">Huly&reg;: <b>GITHB-57</b></a></sub>