### PR TITLE
Demo 12-ANNOTATIONS REDO.

### DIFF
--- a/src/demo/demo-components/DemoWord/DemoWord.css
+++ b/src/demo/demo-components/DemoWord/DemoWord.css
@@ -22,12 +22,19 @@
   margin: 0;
 }
 
-.annotation {
-  height: 3.3rem;
-  text-wrap: wrap;
-  text-align: center;
-  font-size: 0.85rem;
-  color: var(--drk-txt);
+.annotation p {
+  font-size: .9rem;
+  font-family:'Montserrat', 'Roboto', sans-serif;
+}
+
+.saved.zh {
+  text-decoration: underline;
+  text-underline-offset: 4px;
+  text-decoration-thickness: 1.5px;
+}
+
+.meaning {
+  font-weight: bold;
 }
 
 .Word:not(.specialChar) .zh:hover {

--- a/src/demo/demo-components/DemoWord/DemoWord.jsx
+++ b/src/demo/demo-components/DemoWord/DemoWord.jsx
@@ -7,22 +7,21 @@ export default function DemoWord({
   isSaved,
   isSpecialChar,
   onClick,
-}) {
+}) 
+
+{
   return (
     <div className={`Word ${isSpecialChar ? "specialChar" : ""}`}>
       <p
-        className="zh"
+        className={`zh ${isSaved ? 'saved' : ''}`}
         onClick={!isSpecialChar ? onClick : undefined}
-        style={{ color: isSaved ? "var(--red)" : "var(--drk-txt)" }}
+        style={{ color: isSaved ? '#056a6d' : 'var(--drk-txt)'}}
       >
-        {word.text}
+        { word.text }
       </p>
-      <div
-        className="annotation"
-        style={{ visibility: isSaved ? "visible" : "hidden" }}
-      >
-        <p>{pinyin}</p>
-        <p>{meaning}</p>
+      <div className="annotation" style={{ visibility: isSaved ? 'visible' : 'hidden' }}>
+        <p className="pinyin">{pinyin}</p>
+        <p className="meaning">{meaning}</p>
       </div>
     </div>
   );


### PR DESCRIPTION
Added back glyph color change, underlined saved glyphs, changed spacing/thickness of underline, changed font type to be cleaner. This should put us back to where we were. This does not include my most recent changes that I am still incorporating to fix the overflow of the meaning onto the next lines of glyphs.