### PR TITLE
DEMO-45: Move flashcard game logic out of main text page file

### DIFF
--- a/src/demo/demo-components/DemoFlashcardForm/DemoFlashcardForm.jsx
+++ b/src/demo/demo-components/DemoFlashcardForm/DemoFlashcardForm.jsx
@@ -14,11 +14,6 @@ import {
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 
 export default function DemoFlashcardForm({
-  // selectedFront,
-  // setSelectedFront,
-  // showPinyin,
-  // setShowPinyin,
-  // startQuiz,
   localSavedWords,
   handleBackArrowClick,
 }) {
@@ -110,9 +105,6 @@ export default function DemoFlashcardForm({
             className="show-pinyin"
           />
         </FormGroup>
-        {/* <button className="play-btn" onClick={startQuiz}>
-          Start Quiz
-        </button> */}
         <DemoFlashcardGame wordList={localSavedWords} selectedFront={selectedFront} showPinyin={showPinyin} />
       </div>
     </>

--- a/src/demo/demo-components/DemoFlashcardForm/DemoFlashcardForm.jsx
+++ b/src/demo/demo-components/DemoFlashcardForm/DemoFlashcardForm.jsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import "./DemoFlashcardForm.css";
+import DemoFlashcardGame from "../DemoFlashcardGame/DemoFlashcardGame";
 import {
   Radio,
   RadioGroup,
@@ -12,14 +14,16 @@ import {
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 
 export default function DemoFlashcardForm({
-  selectedFront,
-  setSelectedFront,
-  showPinyin,
-  setShowPinyin,
-  startQuiz,
+  // selectedFront,
+  // setSelectedFront,
+  // showPinyin,
+  // setShowPinyin,
+  // startQuiz,
+  localSavedWords,
   handleBackArrowClick,
 }) {
-
+    const [selectedFront, setSelectedFront] = useState("chinese");
+    const [showPinyin, setShowPinyin] = useState(true);
 
   return (
     <>
@@ -106,9 +110,10 @@ export default function DemoFlashcardForm({
             className="show-pinyin"
           />
         </FormGroup>
-        <button className="play-btn" onClick={startQuiz}>
+        {/* <button className="play-btn" onClick={startQuiz}>
           Start Quiz
-        </button>
+        </button> */}
+        <DemoFlashcardGame wordList={localSavedWords} selectedFront={selectedFront} showPinyin={showPinyin} />
       </div>
     </>
   );

--- a/src/demo/demo-components/DemoFlashcardGame/DemoFlashcardGame.css
+++ b/src/demo/demo-components/DemoFlashcardGame/DemoFlashcardGame.css
@@ -1,0 +1,13 @@
+.play-btn {
+    margin-top: 3vmin;
+    font-size: 1.1rem;
+    padding: 1vmin 2vmin;
+    background-color: #006769;
+    color: white;
+    transition: transform 0.3s ease-in-out;
+}
+
+.play-btn:hover {
+    background-color: var(--teal);
+    transform: scale(1.1);
+}

--- a/src/demo/demo-components/DemoFlashcardGame/DemoFlashcardGame.jsx
+++ b/src/demo/demo-components/DemoFlashcardGame/DemoFlashcardGame.jsx
@@ -47,14 +47,14 @@ export default function DemoFlashcardGame({wordList, selectedFront, showPinyin})
     const [correctCount, setCorrectCount] = useState(0);
     const [remainingCount, setRemainingCount] = useState(0);
 
-    function getFlashcards(wordList) {
+    function getFlashcards() {
         const flashcardsArray = wordList.map((word) => ({
             chinese: word.charGroup,
             pinyin: word.pinyin,
             meaning: word.meaning,
             id: word._id,
         }));
-        setFlashcards(flashcardsArray);
+        return flashcardsArray
   }
 
     function handleClose() {
@@ -80,11 +80,11 @@ export default function DemoFlashcardGame({wordList, selectedFront, showPinyin})
     }
 
     function startQuiz() {
-        setOpen(true);
-        getFlashcards(wordList);
-        setRemainingCount(flashcards.length);
-        console.log(flashcards.length);
+        const flashcardsArray = getFlashcards()
+        setFlashcards(flashcardsArray);
+        setRemainingCount(flashcardsArray.length);
         setGameInProgress(true);
+        setOpen(true);
     }
 
     function handlePlayAgain() {

--- a/src/demo/demo-components/DemoFlashcardGame/DemoFlashcardGame.jsx
+++ b/src/demo/demo-components/DemoFlashcardGame/DemoFlashcardGame.jsx
@@ -88,15 +88,17 @@ export default function DemoFlashcardGame({wordList, selectedFront, showPinyin})
     }
 
     function handlePlayAgain() {
-        const flashcardsArray = wordList.map((word) => ({
-            chinese: word.charGroup,
-            pinyin: word.pinyin,
-            meaning: word.meaning,
-            id: word._id,
-        }));
-        setFlashcards(flashcardsArray);
-        setGameInProgress(false);
-        setOpen(true);
+        // const flashcardsArray = wordList.map((word) => ({
+        //     chinese: word.charGroup,
+        //     pinyin: word.pinyin,
+        //     meaning: word.meaning,
+        //     id: word._id,
+        // }));
+        // setFlashcards(flashcardsArray);
+        // setGameInProgress(false);
+        // setOpen(true);
+        setCorrectCount(0)
+        startQuiz()
     }
 
     return (

--- a/src/demo/demo-components/DemoFlashcardGame/DemoFlashcardGame.jsx
+++ b/src/demo/demo-components/DemoFlashcardGame/DemoFlashcardGame.jsx
@@ -17,7 +17,7 @@ export default function DemoFlashcardGame({wordList, selectedFront, showPinyin})
     function handleToggle() {
         setIsFlipped(!isFlipped);
         if (!hasBeenFlipped) {
-        setHasBeenFlipped(true);
+            setHasBeenFlipped(true);
         }
     }
 

--- a/src/demo/demo-components/DemoFlashcardGame/DemoFlashcardGame.jsx
+++ b/src/demo/demo-components/DemoFlashcardGame/DemoFlashcardGame.jsx
@@ -4,41 +4,6 @@ import { Button, Dialog, DialogActions, DialogContent } from "@mui/material";
 import { IoMdClose } from "react-icons/io";
 import { GiCheckMark } from "react-icons/gi";
 import { PiRepeatBold } from "react-icons/pi";
-class Deck {
-        constructor(){
-            this.top = null
-            this.bottom = null
-        }
-        drawCard() {
-            let card = this.top
-            this.top = this.top.next
-            return card
-        }
-        returnCard(card) {
-            this.bottom.next = card
-            card.previous = this.bottom
-            this.bottom = card
-            card.next = null
-        }
-        addNewCard(chinese, pinyin, english) {
-            let newCard = {
-                chinese: chinese,
-                pinyin: pinyin,
-                english: english,
-                next: null,
-                previous: null
-            }
-            if (!this.top) {
-                this.top = newCard
-                this.bottom = newCard
-            }
-            else {
-                this.bottom.next = newCard
-                newCard.previous = this.bottom
-                this.bottom = newCard
-            }
-        }
-    }
 
 export default function DemoFlashcardGame({wordList, selectedFront, showPinyin}) {
     const [open, setOpen] = useState(false);

--- a/src/demo/demo-components/DemoFlashcardGame/DemoFlashcardGame.jsx
+++ b/src/demo/demo-components/DemoFlashcardGame/DemoFlashcardGame.jsx
@@ -40,16 +40,16 @@ class Deck {
         }
     }
 
-export default function DemoFlashcardGame(wordList) {
+export default function DemoFlashcardGame({wordList, selectedFront, showPinyin}) {
     const [open, setOpen] = useState(false);
     const [flashcards, setFlashcards] = useState([]);
-    const [selectedFront, setSelectedFront] = useState("chinese");
-    const [showPinyin, setShowPinyin] = useState(true);
+    // const [selectedFront, setSelectedFront] = useState("chinese");
+    // const [showPinyin, setShowPinyin] = useState(true);
     const [gameInProgress, setGameInProgress] = useState(false);
     const [correctCount, setCorrectCount] = useState(0);
     const [remainingCount, setRemainingCount] = useState(0);
 
-    function getFlashcards() {
+    function getFlashcards(wordList) {
         const flashcardsArray = wordList.map((word) => ({
             chinese: word.charGroup,
             pinyin: word.pinyin,
@@ -83,7 +83,7 @@ export default function DemoFlashcardGame(wordList) {
 
     function startQuiz() {
         setOpen(true);
-        getFlashcards();
+        getFlashcards(wordList);
         setRemainingCount(flashcards.length);
         console.log(flashcards.length);
         setGameInProgress(true);

--- a/src/demo/demo-components/DemoFlashcardGame/DemoFlashcardGame.jsx
+++ b/src/demo/demo-components/DemoFlashcardGame/DemoFlashcardGame.jsx
@@ -1,0 +1,206 @@
+import { useState } from "react"
+import DemoFlashcard from "../../demo-components/DemoFlashcard/DemoFlashcard";
+import { Button, Dialog, DialogActions, DialogContent } from "@mui/material";
+import { FaRegWindowClose } from "react-icons/fa";
+import { GiCheckMark } from "react-icons/gi";
+import { PiRepeatBold } from "react-icons/pi";
+class Deck {
+        constructor(){
+            this.top = null
+            this.bottom = null
+        }
+        drawCard() {
+            let card = this.top
+            this.top = this.top.next
+            return card
+        }
+        returnCard(card) {
+            this.bottom.next = card
+            card.previous = this.bottom
+            this.bottom = card
+            card.next = null
+        }
+        addNewCard(chinese, pinyin, english) {
+            let newCard = {
+                chinese: chinese,
+                pinyin: pinyin,
+                english: english,
+                next: null,
+                previous: null
+            }
+            if (!this.top) {
+                this.top = newCard
+                this.bottom = newCard
+            }
+            else {
+                this.bottom.next = newCard
+                newCard.previous = this.bottom
+                this.bottom = newCard
+            }
+        }
+    }
+
+export default function DemoFlashcardGame(wordList) {
+    const [open, setOpen] = useState(false);
+    const [flashcards, setFlashcards] = useState([]);
+    const [selectedFront, setSelectedFront] = useState("chinese");
+    const [showPinyin, setShowPinyin] = useState(true);
+    const [gameInProgress, setGameInProgress] = useState(false);
+    const [correctCount, setCorrectCount] = useState(0);
+    const [remainingCount, setRemainingCount] = useState(0);
+
+    function getFlashcards() {
+        const flashcardsArray = wordList.map((word) => ({
+            chinese: word.charGroup,
+            pinyin: word.pinyin,
+            meaning: word.meaning,
+            id: word._id,
+        }));
+        setFlashcards(flashcardsArray);
+  }
+
+    function handleClose() {
+        setFlashcards([]);
+        setCorrectCount(0);
+        setGameInProgress(false);
+        setOpen(false);
+    }
+
+    function handleCorrect() {
+        // if the user marks the word correct, create a new array of flashcards removing the 1st one in the array (the one that was correct)
+        setFlashcards((prevFlashcards) => prevFlashcards.slice(1));
+        setCorrectCount(correctCount + 1);
+        setRemainingCount(remainingCount - 1);
+    }
+
+    function handleIncorrect() {
+        // if the user marks the word incorrect, create a new array by removing the 1st card (same as when you get it correct), but instead add it back in at the end of the new array (basically cycles the cards thru)
+        setFlashcards((prevFlashcards) => [
+            ...prevFlashcards.slice(1),
+            prevFlashcards[0],
+        ]);
+    }
+
+    function startQuiz() {
+        setOpen(true);
+        getFlashcards();
+        setRemainingCount(flashcards.length);
+        console.log(flashcards.length);
+        setGameInProgress(true);
+    }
+
+    function handlePlayAgain() {
+        const flashcardsArray = wordList.map((word) => ({
+            chinese: word.charGroup,
+            pinyin: word.pinyin,
+            meaning: word.meaning,
+            id: word._id,
+        }));
+        setFlashcards(flashcardsArray);
+        setGameInProgress(false);
+        setOpen(true);
+    }
+
+    return (
+        <>
+        <button className="play-btn" onClick={startQuiz}>
+          Start Quiz
+        </button>
+        <Dialog
+        open={open}
+        onClose={handleClose}
+        PaperComponent={({ children }) => (
+          <div
+            style={{
+              width: "60vmin",
+              height: "50vmin",
+              backgroundColor: "white",
+              color: "var(--drk-txt)",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              padding: "1vmin",
+              borderRadius: "2vmin",
+            }}
+          >
+            {children}
+          </div>
+        )}
+      >
+        <DialogActions
+          style={{
+            alignSelf: "flex-end",
+            padding: "0",
+          }}
+        >
+          <Button onClick={handleClose}>
+            <FaRegWindowClose className="close-icon" />
+          </Button>
+        </DialogActions>
+        <DialogContent
+          style={{
+            width: "75%",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "space-between",
+          }}
+        >
+          {flashcards.length > 0 && gameInProgress ? (
+            <>
+              <DemoFlashcard
+                chinese={flashcards[0].chinese}
+                pinyin={flashcards[0].pinyin}
+                english={flashcards[0].meaning}
+                selectedFront={selectedFront}
+                showPinyin={showPinyin}
+                onCorrect={handleCorrect}
+                onIncorrect={handleIncorrect}
+                flashcards={flashcards}
+              />
+              <div>
+                <div className="flashcard-btns">
+                  <button className="correct-btn" onClick={handleCorrect}>
+                    <GiCheckMark className="flashcard-icon" />
+                    Correct!
+                  </button>
+                  <button className="incorrect-btn" onClick={handleIncorrect}>
+                    <PiRepeatBold className="flashcard-icon" />
+                    Try again
+                  </button>
+                </div>
+                <div className="flashcard-count">
+                  <p>
+                    <span className="correct-count">{correctCount}</span>{" "}
+                    Correct
+                  </p>
+                  <p>
+                    <span className="remaining-count">{remainingCount}</span>{" "}
+                    Remaining
+                  </p>
+                </div>
+              </div>
+            </>
+          ) : (
+            <div className="congrats">
+              <div>
+                <dotlottie-player
+                  src="https://lottie.host/9279b8f8-2d84-4077-aaf6-db967f8ec7bb/3JRYmBPJgq.json"
+                  background="transparent"
+                  speed="1"
+                  style={{ height: "20vmin" }}
+                  loop
+                  autoplay
+                ></dotlottie-player>
+              </div>
+              <h2>You completed the deck!</h2>
+              <button className="play-btn" onClick={handlePlayAgain}>
+                Play Again
+              </button>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+        </>
+    )
+
+}

--- a/src/demo/demo-components/DemoFlashcardGame/DemoFlashcardGame.jsx
+++ b/src/demo/demo-components/DemoFlashcardGame/DemoFlashcardGame.jsx
@@ -43,8 +43,6 @@ class Deck {
 export default function DemoFlashcardGame({wordList, selectedFront, showPinyin}) {
     const [open, setOpen] = useState(false);
     const [flashcards, setFlashcards] = useState([]);
-    // const [selectedFront, setSelectedFront] = useState("chinese");
-    // const [showPinyin, setShowPinyin] = useState(true);
     const [gameInProgress, setGameInProgress] = useState(false);
     const [correctCount, setCorrectCount] = useState(0);
     const [remainingCount, setRemainingCount] = useState(0);

--- a/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
+++ b/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
@@ -11,7 +11,6 @@ import DemoWelcomeModal from "../../demo-components/DemoWelcomeModal/DemoWelcome
 import DemoExitModal from "../../demo-components/DemoExitModal/DemoExitModal";
 // import * as textsAPI from "../../../utilities/texts-api";
 // import * as wordsAPI from "../../../utilities/words-api";
-import { Button, Dialog, DialogActions, DialogContent } from "@mui/material";
 import { getWordInfo } from "../../../utilities/words-service";
 import DemoLibrary from "../../demo-components/DemoLibrary/DemoLibrary";
 //import word from '../../../../models/word'

--- a/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
+++ b/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
@@ -4,7 +4,6 @@ import DemoStudyText from "../../demo-components/DemoStudyText/DemoStudyText";
 import DemoReadText from "../../demo-components/DemoReadText/DemoReadText";
 import DemoTranslateText from "../../demo-components/DemoTranslateText/DemoTranslateText";
 import DemoSavedWordsList from "../../demo-components/DemoSavedWordsList/DemoSavedWordsList";
-import DemoFlashcard from "../../demo-components/DemoFlashcard/DemoFlashcard";
 import DemoFlashcardForm from "../../demo-components/DemoFlashcardForm/DemoFlashcardForm";
 import DemoInfoSidebar from "../../demo-components/DemoInfoSidebar/DemoInfoSidebar";
 import DemoNav from "../../demo-components/DemoNav/DemoNav";
@@ -12,10 +11,6 @@ import DemoWelcomeModal from "../../demo-components/DemoWelcomeModal/DemoWelcome
 import DemoExitModal from "../../demo-components/DemoExitModal/DemoExitModal";
 // import * as textsAPI from "../../../utilities/texts-api";
 // import * as wordsAPI from "../../../utilities/words-api";
-import { Button, Dialog, DialogActions, DialogContent } from "@mui/material";
-import { FaRegWindowClose } from "react-icons/fa";
-import { GiCheckMark } from "react-icons/gi";
-import { PiRepeatBold } from "react-icons/pi";
 import { getWordInfo } from "../../../utilities/words-service";
 import DemoLibrary from "../../demo-components/DemoLibrary/DemoLibrary";
 //import word from '../../../../models/word'
@@ -63,15 +58,6 @@ export default function DemoTextPage({ getText, updateText }) {
     handleCloseDemoWelcomeModal();
   };
 
-  // --- FLASHCARDS ---
-  const [open, setOpen] = useState(false);
-  const [flashcards, setFlashcards] = useState([]);
-  const [selectedFront, setSelectedFront] = useState("chinese");
-  const [showPinyin, setShowPinyin] = useState(true);
-  const [gameInProgress, setGameInProgress] = useState(false);
-  const [correctCount, setCorrectCount] = useState(0);
-  const [remainingCount, setRemainingCount] = useState(0);
-
   useEffect(
     function () {
       function setLocalStorage() {
@@ -84,16 +70,6 @@ export default function DemoTextPage({ getText, updateText }) {
     },
     [localSavedWords]
   );
-
-  function getFlashcards() {
-    const flashcardsArray = localSavedWords.map((word) => ({
-      chinese: word.charGroup,
-      pinyin: word.pinyin,
-      meaning: word.meaning,
-      id: word._id,
-    }));
-    setFlashcards(flashcardsArray);
-  }
 
   function handleTabClick(tabName) {
     setActiveTab(tabName);
@@ -165,48 +141,6 @@ export default function DemoTextPage({ getText, updateText }) {
     setLocalSavedWords([...filteredWords]);
   }
 
-  function handleClose() {
-    setFlashcards([]);
-    setCorrectCount(0);
-    setGameInProgress(false);
-    setOpen(false);
-  }
-
-  function handleCorrect() {
-    // if the user marks the word correct, create a new array of flashcards removing the 1st one in the array (the one that was correct)
-    setFlashcards((prevFlashcards) => prevFlashcards.slice(1));
-    setCorrectCount(correctCount + 1);
-    setRemainingCount(remainingCount - 1);
-  }
-
-  function handleIncorrect() {
-    // if the user marks the word incorrect, create a new array by removing the 1st card (same as when you get it correct), but instead add it back in at the end of the new array (basically cycles the cards thru)
-    setFlashcards((prevFlashcards) => [
-      ...prevFlashcards.slice(1),
-      prevFlashcards[0],
-    ]);
-  }
-
-  function startQuiz() {
-    setOpen(true);
-    getFlashcards();
-    setRemainingCount(flashcards.length);
-    console.log(flashcards.length);
-    setGameInProgress(true);
-  }
-
-  function handlePlayAgain() {
-    const flashcardsArray = localSavedWords.map((word) => ({
-      chinese: word.charGroup,
-      pinyin: word.pinyin,
-      meaning: word.meaning,
-      id: word._id,
-    }));
-    setFlashcards(flashcardsArray);
-    setGameInProgress(false);
-    setOpen(true);
-  }
-
   //state that will be used to store data that will determine which sidebar content to present based on which sidebar is clicked.
   const [sidebarCategory, setSidebarCategory] = useState(null);
 
@@ -256,8 +190,6 @@ export default function DemoTextPage({ getText, updateText }) {
               savedWords={localSavedWords}
               updateWord={updateWord}
               deleteWord={deleteWord}
-              startQuiz={startQuiz}
-              gameInProgress={gameInProgress}
               handleBackArrowClick={handleBackArrowClick}
             />
           )}
@@ -285,101 +217,6 @@ export default function DemoTextPage({ getText, updateText }) {
           )}
         </aside>
       )}
-
-      <Dialog
-        open={open}
-        onClose={handleClose}
-        PaperComponent={({ children }) => (
-          <div
-            style={{
-              width: "60vmin",
-              height: "50vmin",
-              backgroundColor: "white",
-              color: "var(--drk-txt)",
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              padding: "1vmin",
-              borderRadius: "2vmin",
-            }}
-          >
-            {children}
-          </div>
-        )}
-      >
-        <DialogActions
-          style={{
-            alignSelf: "flex-end",
-            padding: "0",
-          }}
-        >
-          <Button onClick={handleClose}>
-            <FaRegWindowClose className="close-icon" />
-          </Button>
-        </DialogActions>
-        <DialogContent
-          style={{
-            width: "75%",
-            display: "flex",
-            flexDirection: "column",
-            justifyContent: "space-between",
-          }}
-        >
-          {flashcards.length > 0 && gameInProgress ? (
-            <>
-              <DemoFlashcard
-                chinese={flashcards[0].chinese}
-                pinyin={flashcards[0].pinyin}
-                english={flashcards[0].meaning}
-                selectedFront={selectedFront}
-                showPinyin={showPinyin}
-                onCorrect={handleCorrect}
-                onIncorrect={handleIncorrect}
-                flashcards={flashcards}
-              />
-              <div>
-                <div className="flashcard-btns">
-                  <button className="correct-btn" onClick={handleCorrect}>
-                    <GiCheckMark className="flashcard-icon" />
-                    Correct!
-                  </button>
-                  <button className="incorrect-btn" onClick={handleIncorrect}>
-                    <PiRepeatBold className="flashcard-icon" />
-                    Try again
-                  </button>
-                </div>
-                <div className="flashcard-count">
-                  <p>
-                    <span className="correct-count">{correctCount}</span>{" "}
-                    Correct
-                  </p>
-                  <p>
-                    <span className="remaining-count">{remainingCount}</span>{" "}
-                    Remaining
-                  </p>
-                </div>
-              </div>
-            </>
-          ) : (
-            <div className="congrats">
-              <div>
-                <dotlottie-player
-                  src="https://lottie.host/9279b8f8-2d84-4077-aaf6-db967f8ec7bb/3JRYmBPJgq.json"
-                  background="transparent"
-                  speed="1"
-                  style={{ height: "20vmin" }}
-                  loop
-                  autoplay
-                ></dotlottie-player>
-              </div>
-              <h2>You completed the deck!</h2>
-              <button className="play-btn" onClick={handlePlayAgain}>
-                Play Again
-              </button>
-            </div>
-          )}
-        </DialogContent>
-      </Dialog>
 
       <section className="main-area">
         <div className="tabs sticky-fade">

--- a/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
+++ b/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
@@ -265,11 +265,6 @@ export default function DemoTextPage({ getText, updateText }) {
             <DemoFlashcardForm
               expandSidebar={expandSidebar}
               changeSidebarCategory={changeSidebarCategory}
-              // selectedFront={selectedFront}
-              // setSelectedFront={setSelectedFront}
-              // showPinyin={showPinyin}
-              // setShowPinyin={setShowPinyin}
-              // startQuiz={startQuiz}
               localSavedWords={localSavedWords}
               handleBackArrowClick={handleBackArrowClick}
             />

--- a/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
+++ b/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
@@ -265,11 +265,12 @@ export default function DemoTextPage({ getText, updateText }) {
             <DemoFlashcardForm
               expandSidebar={expandSidebar}
               changeSidebarCategory={changeSidebarCategory}
-              selectedFront={selectedFront}
-              setSelectedFront={setSelectedFront}
-              showPinyin={showPinyin}
-              setShowPinyin={setShowPinyin}
-              startQuiz={startQuiz}
+              // selectedFront={selectedFront}
+              // setSelectedFront={setSelectedFront}
+              // showPinyin={showPinyin}
+              // setShowPinyin={setShowPinyin}
+              // startQuiz={startQuiz}
+              localSavedWords={localSavedWords}
               handleBackArrowClick={handleBackArrowClick}
             />
           )}


### PR DESCRIPTION
Created a new `DemoFlashcardGame` component to hold the logic and rendering of flashcard quiz and modal.
This new component now contains all of the state variables for the game, as well as update and logic functions. It renders as the "Start Quiz" button on the Flashcard Form sidebar component, and that button will change the 'open' state to show the Dialog. I fixed an issue I encountered where the "play again" button wasn't resetting the quiz, just causing the completion animation to replay. Other than that, everything about the game works the same and nothing has been changed other than the refactoring of components.


https://github.com/user-attachments/assets/11b563e9-07b8-4cdf-9c3e-4285328dc3ed

