### PR TITLE
DEMO-14: Improve UI for sentence translations

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:ital,wght@0,100..900;1,100..900&family=Merriweather:ital,wght@0,300;0,400;0,700;0,900;1,300;1,400;1,700;1,900&family=Noto+Sans+TC:wght@100..900&family=Noto+Serif+TC:wght@200..900&display=swap" rel="stylesheet">
     
     <!-- For all google icons -->
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" rel="stylesheet" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:ital,wght@0,100..900;1,100..900&family=Merriweather:ital,wght@0,300;0,400;0,700;0,900;1,300;1,400;1,700;1,900&family=Noto+Sans+TC:wght@100..900&family=Noto+Serif+TC:wght@200..900&display=swap" rel="stylesheet">
+    
+    <!-- For all google icons -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/src/demo/demo-components/DemoReadText/DemoReadText.css
+++ b/src/demo/demo-components/DemoReadText/DemoReadText.css
@@ -241,3 +241,10 @@
 
 }
 
+@media (max-width: 400px) { 
+  .text-area {
+    padding: 0 0 0 10vmin;
+  }
+
+}
+

--- a/src/demo/demo-components/DemoSentence/DemoSentence.css
+++ b/src/demo/demo-components/DemoSentence/DemoSentence.css
@@ -5,6 +5,7 @@
 
 .sentence {
   margin: 1vmin 0;
+  font-weight: 500;
   font-size: 1.5rem;
   line-height: 32px;
   letter-spacing: 0.3rem;

--- a/src/demo/demo-components/DemoSentence/DemoSentence.css
+++ b/src/demo/demo-components/DemoSentence/DemoSentence.css
@@ -5,7 +5,7 @@
 
 .sentence {
   margin: 1vmin 0;
-  font-weight: 500;
+  font-weight: 400;
   font-size: 1.5rem;
   line-height: 32px;
   letter-spacing: 0.3rem;

--- a/src/demo/demo-components/DemoSentence/DemoSentence.css
+++ b/src/demo/demo-components/DemoSentence/DemoSentence.css
@@ -11,10 +11,12 @@
 .toggle-translation {
   position: absolute;
   color: var(--primary);
+  background-color: inherit;
   left: -3.4rem;
-  top: 0.4rem;
-  font-size: 2rem;
+  top: 1.2rem;
+  font-size: 1.8rem;
   padding: 5px;
+  margin-left: 0px;
   cursor: pointer;
 }
 

--- a/src/demo/demo-components/DemoSentence/DemoSentence.css
+++ b/src/demo/demo-components/DemoSentence/DemoSentence.css
@@ -1,5 +1,6 @@
 .sentence-line {
   margin-bottom: 2vmin;
+  position: relative;
 }
 
 .sentence {
@@ -7,15 +8,27 @@
   letter-spacing: .7vmin;
 }
 
-.hide-translation,
-.show-translation {
-  letter-spacing: 0;
-  text-decoration: underline;
-  font-size: 2vmin;
+.toggle-translation {
+  position: absolute;
+  color: var(--primary);
+  left: -3.4rem;
+  top: 0.4rem;
+  font-size: 2rem;
+  padding: 5px;
+  cursor: pointer;
 }
 
-.hide-translation:hover,
-.show-translation:hover {
-  color: var(--red);
-  cursor: pointer;
+.toggle-translation:hover,
+.toggle-translation.translation-visible {
+  color: var(--white);
+  background-color: var(--primary);
+  border-radius: 100%;
+}
+
+/* small screens and smaller */
+@media (max-width: 400px) { 
+  .toggle-translation {
+    left: -2.8rem;
+  }
+
 }

--- a/src/demo/demo-components/DemoSentence/DemoSentence.css
+++ b/src/demo/demo-components/DemoSentence/DemoSentence.css
@@ -5,7 +5,10 @@
 
 .sentence {
   margin: 1vmin 0;
-  letter-spacing: .7vmin;
+  font-size: 1.5rem;
+  line-height: 32px;
+  letter-spacing: 0.3rem;
+  color: black;
 }
 
 .toggle-translation {

--- a/src/demo/demo-components/DemoSentence/DemoSentence.jsx
+++ b/src/demo/demo-components/DemoSentence/DemoSentence.jsx
@@ -24,14 +24,14 @@ export default function DemoSentence({ sentence }) {
     <>
       <div className="sentence-line">
         {/* Google Icons translate Icon */}
-        <span
+        <button
           className={`material-symbols-outlined toggle-translation ${
             showTranslation ? "translation-visible" : ""
           }`}
           onClick={() => handleTranslate(sentence)}
         >
           translate
-        </span>
+        </button>
         <span className="sentence zh">{sentence}</span>
       </div>
       {translation && (

--- a/src/demo/demo-components/DemoSentence/DemoSentence.jsx
+++ b/src/demo/demo-components/DemoSentence/DemoSentence.jsx
@@ -30,7 +30,7 @@ export default function DemoSentence({ sentence }) {
           }`}
           onClick={() => handleTranslate(sentence)}
         >
-          translate
+          &#xe8e2;
         </button>
         <span className="sentence zh">{sentence}</span>
       </div>

--- a/src/demo/demo-components/DemoSentence/DemoSentence.jsx
+++ b/src/demo/demo-components/DemoSentence/DemoSentence.jsx
@@ -1,38 +1,42 @@
-import './DemoSentence.css'
-import * as demoAPI from '../../../utilities/demo-api'
-import { useState } from 'react'
-import DemoTranslation from '../DemoTranslation/DemoTranslation'
+import "./DemoSentence.css";
+import * as demoAPI from "../../../utilities/demo-api";
+import { useState, useEffect } from "react";
+import DemoTranslation from "../DemoTranslation/DemoTranslation";
 
-export default function DemoSentence({sentence}) {
-  const [translation, setTranslation] = useState('');
-  const [showTranslation, setShowTranslation] = useState(false)
+export default function DemoSentence({ sentence }) {
+  const [translation, setTranslation] = useState("");
+  const [showTranslation, setShowTranslation] = useState(false);
 
-  async function handleTranslate(sentence) {
-    if (translation === '') {
-      const translatedSentence = await demoAPI.translateSentence(sentence)
-      setTranslation(translatedSentence)
-      setShowTranslation(true)
-    } else {
-      setShowTranslation(true)
-    }
-  }
+  useEffect(() => {
+    const fetchTranslation = async () => {
+      const translatedSentence = await demoAPI.translateSentence(sentence);
+      setTranslation(translatedSentence);
+    };
 
-  function hideTranslation() {
-    setShowTranslation(false)
-  }
+    fetchTranslation();
+  }, [sentence]);
+
+  const handleTranslate = () => {
+    setShowTranslation(!showTranslation);
+  };
 
   return (
     <>
-    <div className="sentence-line">
-      <span className="sentence zh">{sentence}</span>
-        { showTranslation ? (
-          <p className="hide-translation" onClick={hideTranslation}>Hide Translation</p>
-        ) : (
-          <p className="show-translation" onClick={() => handleTranslate(sentence)}>Show Translation</p>
-        )
-        }
-    </div>
-      {translation && showTranslation && <DemoTranslation translation={translation}/>}
+      <div className="sentence-line">
+        {/* Google Icons translate Icon */}
+        <span
+          className={`material-symbols-outlined toggle-translation ${
+            showTranslation ? "translation-visible" : ""
+          }`}
+          onClick={() => handleTranslate(sentence)}
+        >
+          translate
+        </span>
+        <span className="sentence zh">{sentence}</span>
+      </div>
+      {translation && (
+        <DemoTranslation translation={translation} show={showTranslation} />
+      )}
     </>
-  )
+  );
 }

--- a/src/demo/demo-components/DemoTranslateText/DemoTranslateText.css
+++ b/src/demo/demo-components/DemoTranslateText/DemoTranslateText.css
@@ -9,7 +9,6 @@
 
 .translate-text-block {
   margin-top: 2vmin;
-  line-height: 3.1rem;
   font-size: 1.8rem;
   text-align: left;
   max-width: 900px;

--- a/src/demo/demo-components/DemoTranslation/DemoTranslation.css
+++ b/src/demo/demo-components/DemoTranslation/DemoTranslation.css
@@ -1,9 +1,9 @@
 .translation {
   letter-spacing: 0;
-  font-size: 1.2rem;
+  font-size: 1.1rem;
   margin: 1vmin 0 4vmin 0;
   color: var(--black);
-
+  line-height: 1.8rem;
   /* Transition properties */
   max-height: 0;
   opacity: 0;

--- a/src/demo/demo-components/DemoTranslation/DemoTranslation.css
+++ b/src/demo/demo-components/DemoTranslation/DemoTranslation.css
@@ -8,7 +8,7 @@
   max-height: 0;
   opacity: 0;
   overflow: hidden;
-  transition: max-height 1.8s ease-in-out, opacity 0.9s ease-in-out;
+  transition: max-height 1.2s ease-in-out, opacity 0.5s ease-in-out;
 }
 
 .translation.show-container {

--- a/src/demo/demo-components/DemoTranslation/DemoTranslation.css
+++ b/src/demo/demo-components/DemoTranslation/DemoTranslation.css
@@ -2,7 +2,18 @@
   letter-spacing: 0;
   font-size: 1.2rem;
   margin: 1vmin 0 4vmin 0;
-  color: var(--red)
+  color: var(--black);
+
+  /* Transition properties */
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition: max-height 1.8s ease-in-out, opacity 0.9s ease-in-out;
+}
+
+.translation.show-container {
+  max-height: 1200px;
+  opacity: 1;
 }
 
 /* small screens and smaller */

--- a/src/demo/demo-components/DemoTranslation/DemoTranslation.jsx
+++ b/src/demo/demo-components/DemoTranslation/DemoTranslation.jsx
@@ -1,7 +1,7 @@
 import './DemoTranslation.css'
 
-export default function DemoTranslation({ translation }) {
+export default function DemoTranslation({ translation, show }) {
   return (
-    <p className="translation zh">{ translation }</p>
+    <p className={`translation zh ${show ? 'show-container' : ''}`}>{ translation }</p>
   )
 }


### PR DESCRIPTION
This is updating the translation tab's UI, which includes: 

- replacing show/hide translation text with a google icon
- adding hover and selected styling/functionality to translate icon
- transition animation when user clicks the translate icon
- moved sentence translation into a useEffect so it can start translating on page render. It otherwise took some time for the text to load

![image](https://github.com/user-attachments/assets/d8746fdf-607c-4c34-9d0c-61bb1bae4387)
