### PR TITLE
Add header size scales with paragraph

### DIFF
--- a/src/demo/demo-components/DemoReadText/DemoReadText.css
+++ b/src/demo/demo-components/DemoReadText/DemoReadText.css
@@ -150,7 +150,7 @@
 
 .flex-row h1 {
   font-weight: bolder;
-  font-size: 6vmin;
+  font-size: 400%;
 }
 
 .disclaimer {


### PR DESCRIPTION
The demo header font size now scales with the paragraph font when zooming in/out.