### PR TITLE
DEMO-37: Hide Saved Words During Flashcard Activity

### DIFF
--- a/src/demo/demo-components/DemoFlashcardForm/DemoFlashcardForm.jsx
+++ b/src/demo/demo-components/DemoFlashcardForm/DemoFlashcardForm.jsx
@@ -16,6 +16,7 @@ import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 export default function DemoFlashcardForm({
   localSavedWords,
   handleBackArrowClick,
+  blurText
 }) {
     const [selectedFront, setSelectedFront] = useState("chinese");
     const [showPinyin, setShowPinyin] = useState(true);
@@ -105,7 +106,7 @@ export default function DemoFlashcardForm({
             className="show-pinyin"
           />
         </FormGroup>
-        <DemoFlashcardGame wordList={localSavedWords} selectedFront={selectedFront} showPinyin={showPinyin} />
+        <DemoFlashcardGame wordList={localSavedWords} selectedFront={selectedFront} showPinyin={showPinyin} blurText={blurText} />
       </div>
     </>
   );

--- a/src/demo/demo-components/DemoFlashcardGame/DemoFlashcardGame.jsx
+++ b/src/demo/demo-components/DemoFlashcardGame/DemoFlashcardGame.jsx
@@ -5,7 +5,7 @@ import { IoMdClose } from "react-icons/io";
 import { GiCheckMark } from "react-icons/gi";
 import { PiRepeatBold } from "react-icons/pi";
 
-export default function DemoFlashcardGame({wordList, selectedFront, showPinyin}) {
+export default function DemoFlashcardGame({wordList, selectedFront, showPinyin, blurText}) {
     const [open, setOpen] = useState(false);
     const [flashcards, setFlashcards] = useState([]);
     const [gameInProgress, setGameInProgress] = useState(false);
@@ -37,6 +37,7 @@ export default function DemoFlashcardGame({wordList, selectedFront, showPinyin})
         setGameInProgress(false);
         setOpen(false);
         setHasBeenFlipped(false);
+        blurText(false);
     }
 
     function handleCorrect() {
@@ -64,6 +65,7 @@ export default function DemoFlashcardGame({wordList, selectedFront, showPinyin})
         setRemainingCount(flashcardsArray.length);
         setGameInProgress(true);
         setOpen(true);
+        blurText(true);
     }
 
     function handlePlayAgain() {

--- a/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
+++ b/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
@@ -59,6 +59,7 @@ export default function DemoTextPage({ getText, updateText }) {
   };
 
   const topRef = useRef(null);
+  const blurRef = useRef(null);
 
   useEffect(
     function () {
@@ -168,6 +169,15 @@ export default function DemoTextPage({ getText, updateText }) {
     changeSidebarCategory(toolTipId);
   }
 
+  const blurText = (isActive) => {
+    if (isActive) {
+      blurRef.current.style.filter = 'blur(4px)'
+    }
+    else {
+      blurRef.current.removeAttribute('style')
+    }
+  }
+
   return !text ? (
     "Loading ..."
   ) : (
@@ -202,6 +212,7 @@ export default function DemoTextPage({ getText, updateText }) {
               changeSidebarCategory={changeSidebarCategory}
               localSavedWords={localSavedWords}
               handleBackArrowClick={handleBackArrowClick}
+              blurText={blurText}
             />
           )}
           {sidebarCategory === "info-tooltip" && (
@@ -243,7 +254,7 @@ export default function DemoTextPage({ getText, updateText }) {
           </button>
         </div>
 
-        <div className="text-area">
+        <div className="text-area" ref={blurRef}>
           <div className="textpage-heading">
             <div className="flex-row">
               <h1 className="textpage-heading-title zh">{text.title}</h1>


### PR DESCRIPTION
The text area will now blur when the flashcard quiz is active. This blur will apply whether on the read, study, or translate tab when opening the quiz. This seemed like the easiest solution to stop the user "cheating" by seeing answers in the background.
This was achieved by adding a `blurRef` to the text area and then creating an update function. The update function will add a blur filter to the component via inline staying when it receives `true` and will remove the in-line style when receiving `false`.  The update function is passed down to the game component. The `blurText` function was added to both the `startQuiz` and `handleClose` functions.


https://github.com/user-attachments/assets/04ed03d8-e362-4142-88cf-d7ab0fe075c6

