### PR TITLE
DEMO-48: [Fix] User can save the same word repeatedly

### DIFF
--- a/src/demo/demo-components/DemoPopup/DemoPopup.css
+++ b/src/demo/demo-components/DemoPopup/DemoPopup.css
@@ -82,6 +82,16 @@
   color: white;
 }
 
+.saved-button {
+  background-color: inherit !important;
+  color: #62BFAF;
+}
+
+:disabled {
+  /* opacity: 50%; */
+  cursor: auto;
+}
+
 /* medium screens and smaller */
 @media (max-width: 768px) { 
 

--- a/src/demo/demo-components/DemoPopup/DemoPopup.jsx
+++ b/src/demo/demo-components/DemoPopup/DemoPopup.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import './DemoPopup.css'
 
-export default function Popup({ word, popupPosition, saveWord, textId, onClose }) {
+export default function Popup({ word, popupPosition, saveWord, textId, onClose, checkSaved }) {
   const [popupHeight, setPopupHeight] = useState('15%');
   const popupRef = useRef(null);
 
@@ -40,7 +40,7 @@ export default function Popup({ word, popupPosition, saveWord, textId, onClose }
         saveWord(word);
       }
 
-  
+  const isSaved = checkSaved(word);
 
   return (
       <div
@@ -66,7 +66,7 @@ export default function Popup({ word, popupPosition, saveWord, textId, onClose }
           )}
         </p>
       </div>
-      <button className="save-button" onClick={handleSaveClick}> + </button> &nbsp; 
+      {!isSaved && (<button className="save-button" onClick={handleSaveClick}> + </button>)}&nbsp;      
       <button className="close-btn" onClick={onClose}> x </button>
       <div className="popup-arrow" />
     </div>

--- a/src/demo/demo-components/DemoPopup/DemoPopup.jsx
+++ b/src/demo/demo-components/DemoPopup/DemoPopup.jsx
@@ -66,7 +66,8 @@ export default function Popup({ word, popupPosition, saveWord, textId, onClose, 
           )}
         </p>
       </div>
-      {!isSaved && (<button className="save-button" onClick={handleSaveClick}> + </button>)}&nbsp;      
+      {!isSaved ? (<button className="save-button" onClick={handleSaveClick}> + </button>) : (<button className="save-button saved-button" disabled="true"> ✓ </button>)}&nbsp;
+      {/* <button className="save-button" onClick={handleSaveClick} disabled={isSaved}> + </button>&nbsp; */}
       <button className="close-btn" onClick={onClose}> x </button>
       <div className="popup-arrow" />
     </div>

--- a/src/demo/demo-components/DemoStudyText/DemoStudyText.jsx
+++ b/src/demo/demo-components/DemoStudyText/DemoStudyText.jsx
@@ -112,6 +112,7 @@ export default function DemoStudyText({ text, textId, activeWord, setActiveWord,
           popupPosition={popupPosition}
           saveWord={(word) => saveWord(word, textId)}
           onClose={handlePopup}
+          checkSaved={checkSaved}
         />
       )}
     </>


### PR DESCRIPTION
This fix prevents the ability to save the same word multiple times from the study tab.
I passed down the `checkSaved` function to the word popup in order to implement conditional rendering on the save button. Now, if a word has already been saved to the library, the user will see a check mark instead of the add button and will not be able to add the word to their saved terms again.
The check mark alternative element is still a button element, to facilitate an easy update in the future should we move to adding 'remove word' capabilities to the popup.

<img width="334" alt="saved_word" src="https://github.com/user-attachments/assets/2c2b7cf0-2e23-4d7e-b603-9a8434fbce0f">

https://github.com/user-attachments/assets/e1219872-8402-44e7-96c5-caabfc3d0658

