### PR TITLE
DEMO 50: Set first sentence to be open (translated) by default

### DIFF
--- a/src/demo/demo-components/DemoSentence/DemoSentence.jsx
+++ b/src/demo/demo-components/DemoSentence/DemoSentence.jsx
@@ -3,9 +3,9 @@ import * as demoAPI from "../../../utilities/demo-api";
 import { useState, useEffect } from "react";
 import DemoTranslation from "../DemoTranslation/DemoTranslation";
 
-export default function DemoSentence({ sentence }) {
+export default function DemoSentence({ sentence, isFirst }) {
   const [translation, setTranslation] = useState("");
-  const [showTranslation, setShowTranslation] = useState(false);
+  const [showTranslation, setShowTranslation] = useState(isFirst || false);
 
   useEffect(() => {
     const fetchTranslation = async () => {

--- a/src/demo/demo-components/DemoTranslateText/DemoTranslateText.jsx
+++ b/src/demo/demo-components/DemoTranslateText/DemoTranslateText.jsx
@@ -9,6 +9,7 @@ export default function DemoTranslateText({ text }) {
     <DemoSentence
       key={idx}
       sentence={sentence}
+      isFirst={idx === 0}
     />
   ))
 


### PR DESCRIPTION
First text block on translation tab shows on page render.

<sub><a href="https://huly.app/guest/knownative?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmQzMmQzZGQzNDkxNjA0YmIwZjk3OWUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWJpZ2FpbGRhd3NvLWtub3duYXRpdmUtNjYzMjgxYjEtODdiZTE2ZDY5OS0yYTZiY2QifQ.GgBQaKApdDc7Jj947grLIlkoNTgxKN4Matxk736FpE8">Huly&reg;: <b>GITHB-100</b></a></sub>