### PR TITLE
DEMO-51/DEMO-52: Add Link to Article Source

### DIFF
--- a/src/demo/demo-components/DemoPreviewTextModal/DemoPreviewTextModal.jsx
+++ b/src/demo/demo-components/DemoPreviewTextModal/DemoPreviewTextModal.jsx
@@ -1,6 +1,7 @@
 import "./DemoPreviewTextModal.css";
 import { Modal } from "react-bootstrap";
 import { BsX } from "react-icons/bs";
+import { BiLinkExternal } from "react-icons/bi";
 import DemoDifficultyTag from "../DemoDifficultyTag/DemoDifficultyTag";
 import demoTexts from "../../demodata";
 
@@ -55,7 +56,7 @@ function DemoPreviewTextModal({
               target="_blank"
               rel="noreferrer"
             >
-              View Source
+              View Source <BiLinkExternal />
             </a>
           </section>
           <section className="show-preview-modal-text">

--- a/src/demo/demo-pages/DemoTextPage/DemoTextPage.css
+++ b/src/demo/demo-pages/DemoTextPage/DemoTextPage.css
@@ -21,6 +21,13 @@
   margin-top: 1.5rem;
 }
 
+.link-view-source {
+  text-decoration: underline;
+  color: #576163;
+  margin-left: 2.5vmin;
+  vertical-align: middle;
+}
+
 .text-area {
   background: white;
   padding: 2vmin;

--- a/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
+++ b/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { BiLinkExternal } from "react-icons/bi";
 import "./DemoTextPage.css";
 import DemoStudyText from "../../demo-components/DemoStudyText/DemoStudyText";
 import DemoReadText from "../../demo-components/DemoReadText/DemoReadText";
@@ -257,7 +258,16 @@ export default function DemoTextPage({ getText, updateText }) {
               <h1 className="textpage-heading-title zh">{text.title}</h1>
               <article className="textpage-difficulty-tag">
                 <DemoDifficultyTag textSelection={textSelection} />
+                <a
+                  href={text.source}
+                  className="link-view-source"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  View Source <BiLinkExternal />
+                </a>
               </article>
+            
             </div>
           </div>
 


### PR DESCRIPTION
Adds a simple link element next to the difficulty tag which dynamically links to the source of the currently loaded article. Includes an icon to indicate link will open in another tab.

<img width="978" src="https://github.com/user-attachments/assets/50868dae-3097-49d0-bac9-84a1e9a9b2d6" alt="Screenshot 2024-09-06 at 5 08 51 PM">

<sub><a href="https://huly.app/guest/knownative?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmRiOWE3NTNiYjU3YTg1ZThlZTVjNTkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWJpZ2FpbGRhd3NvLWtub3duYXRpdmUtNjYzMjgxYjEtODdiZTE2ZDY5OS0yYTZiY2QifQ.4K0tYFMRZXJZ5FIuy-NkCkRD3py4zinDo5-RZELlAzg">Huly&reg;: <b>GITHB-106</b></a></sub>