### PR TITLE
DEMO-62: Disable flashcard activity when no words have been saved

### DIFF
--- a/src/demo/demo-components/DemoFlashcardForm/DemoFlashcardForm.css
+++ b/src/demo/demo-components/DemoFlashcardForm/DemoFlashcardForm.css
@@ -33,16 +33,7 @@
   margin-top: 0.5rem;
 }
 
-.play-btn {
-  margin-top: 3vmin;
-  font-size: 1.1rem;
-  padding: 1vmin 2vmin;
-  background-color: #006769;
-  color: white;
-  transition: transform 0.3s ease-in-out;
-}
-
-.play-btn:hover {
-  background-color: var(--teal);
-  transform: scale(1.1);
+.quiz-subtext {
+  text-align: left;
+  margin-top: 2vmin;
 }

--- a/src/demo/demo-components/DemoFlashcardForm/DemoFlashcardForm.jsx
+++ b/src/demo/demo-components/DemoFlashcardForm/DemoFlashcardForm.jsx
@@ -7,7 +7,6 @@ import {
     FormControlLabel,
     FormControl,
     FormGroup,
-    Switch,
     Checkbox,
     FormLabel,
 } from "@mui/material";
@@ -20,6 +19,9 @@ export default function DemoFlashcardForm({
 }) {
     const [selectedFront, setSelectedFront] = useState("chinese");
     const [showPinyin, setShowPinyin] = useState(true);
+
+    // checking if there's saved words to enable/disable quiz
+    const hasSavedWords = localSavedWords && localSavedWords.length > 0;
 
     return (
         <>
@@ -35,75 +37,90 @@ export default function DemoFlashcardForm({
                         />
                     </div>
                 </header>
-                <FormGroup>
-                    <FormLabel
-                        id="radio-buttons-group-label"
-                        className="radio-buttons-group-label"
-                        sx={{ color: "black" }}>
-                        <p>Review your saved terms with a short quiz.</p>
-                        <p>Choose which to display on the front:</p>
-                    </FormLabel>
-                    <FormControl>
-                        <RadioGroup
-                            column
-                            aria-labelledby="demo-row-radio-buttons-group-label"
-                            name="row-radio-buttons-group"
-                            className="radio-buttons-group">
-                            <FormControlLabel
-                                value="chinese"
-                                control={
-                                    <Radio
-                                        sx={{
-                                            paddingTop: "0px",
-                                            paddingBottom: "0px",
-                                            "&.Mui-checked": {
-                                                color: "#00b9bc",
-                                            },
-                                        }}
-                                    />
-                                }
-                                label="Chinese"
-                                checked={selectedFront === "chinese"}
-                                onChange={() => setSelectedFront("chinese")}
-                            />
-                            <FormControlLabel
-                                value="english"
-                                control={
-                                    <Radio
-                                        sx={{
-                                            paddingTop: "0px",
-                                            paddingBottom: "0px",
-                                            "&.Mui-checked": {
-                                                color: "#00b9bc",
-                                            },
-                                        }}
-                                    />
-                                }
-                                label="English"
-                                checked={selectedFront === "english"}
-                                onChange={() => setSelectedFront("english")}
-                            />
-                        </RadioGroup>
-                    </FormControl>
-                </FormGroup>
-                <FormGroup>
-                    <FormControlLabel
-                        control={
-                            <Checkbox
-                                checked={showPinyin}
-                                onChange={() => setShowPinyin(!showPinyin)}
-                                sx={{
-                                    color: "black",
-                                    "&.Mui-checked": {
-                                        color: "#00b9bc",
-                                    },
-                                }}
-                            />
-                        }
-                        label="Show pinyin"
-                        className="show-pinyin"
-                    />
-                </FormGroup>
+                {hasSavedWords ? (
+                <>
+                    <FormGroup>
+                        <FormLabel
+                            id="radio-buttons-group-label"
+                            className="radio-buttons-group-label"
+                            sx={{ color: "black" }}>
+                            <p>Review your saved terms with a short quiz.</p>
+                            <p>Choose which to display on the front:</p>
+                        </FormLabel>
+                        <FormControl>
+                            <RadioGroup
+                                column
+                                aria-labelledby="demo-row-radio-buttons-group-label"
+                                name="row-radio-buttons-group"
+                                className="radio-buttons-group">
+                                <FormControlLabel
+                                    value="chinese"
+                                    control={
+                                        <Radio
+                                            sx={{
+                                                paddingTop: "0px",
+                                                paddingBottom: "0px",
+                                                "&.Mui-checked": {
+                                                    color: "#00b9bc",
+                                                },
+                                            }}
+                                        />
+                                    }
+                                    label="Chinese"
+                                    checked={selectedFront === "chinese"}
+                                    onChange={() => setSelectedFront("chinese")}
+                                />
+                                <FormControlLabel
+                                    value="english"
+                                    control={
+                                        <Radio
+                                            sx={{
+                                                paddingTop: "0px",
+                                                paddingBottom: "0px",
+                                                "&.Mui-checked": {
+                                                    color: "#00b9bc",
+                                                },
+                                            }}
+                                        />
+                                    }
+                                    label="English"
+                                    checked={selectedFront === "english"}
+                                    onChange={() => setSelectedFront("english")}
+                                />
+                            </RadioGroup>
+                        </FormControl>
+                    </FormGroup>
+                    <FormGroup>
+                        <FormControlLabel
+                            control={
+                                <Checkbox
+                                    checked={showPinyin}
+                                    onChange={() => setShowPinyin(!showPinyin)}
+                                    sx={{
+                                        color: "black",
+                                        "&.Mui-checked": {
+                                            color: "#00b9bc",
+                                        },
+                                    }}
+                                />
+                            }
+                            label="Show pinyin"
+                            className="show-pinyin"
+                        />
+                    </FormGroup>
+                </>
+                ) : 
+                <>
+                    <div className="quiz-subtext">
+                    <p>No words have been saved yet!</p>
+                    <p>
+                        Get started by navigating to the Study tab and selecting some words
+                        you'd like to study.
+                    </p>
+                    </div>
+                
+                </>
+                }
                 <DemoFlashcardGame
                     wordList={localSavedWords}
                     selectedFront={selectedFront}

--- a/src/demo/demo-components/DemoFlashcardGame/DemoFlashcardGame.css
+++ b/src/demo/demo-components/DemoFlashcardGame/DemoFlashcardGame.css
@@ -1,4 +1,4 @@
-.play-btn {
+.quiz-play-btn {
     margin-top: 3vmin;
     font-size: 1.1rem;
     padding: 1vmin 2vmin;
@@ -7,7 +7,15 @@
     transition: transform 0.3s ease-in-out;
 }
 
-.play-btn:hover {
+.quiz-play-btn:not(:disabled):hover {
     background-color: var(--teal);
     transform: scale(1.1);
+}
+
+.quiz-play-btn:disabled {
+    margin-top: 3vmin;
+    font-size: 1.1rem;
+    padding: 1vmin 2vmin;
+    background-color: var(--medium);
+    opacity: 0.6;
 }

--- a/src/demo/demo-components/DemoFlashcardGame/DemoFlashcardGame.jsx
+++ b/src/demo/demo-components/DemoFlashcardGame/DemoFlashcardGame.jsx
@@ -4,6 +4,7 @@ import { Button, Dialog, DialogActions, DialogContent } from "@mui/material";
 import { IoMdClose } from "react-icons/io";
 import { GiCheckMark } from "react-icons/gi";
 import { PiRepeatBold } from "react-icons/pi";
+import "./DemoFlashcardGame.css"
 
 export default function DemoFlashcardGame({wordList, selectedFront, showPinyin, blurText}) {
     const [open, setOpen] = useState(false);
@@ -94,7 +95,7 @@ export default function DemoFlashcardGame({wordList, selectedFront, showPinyin, 
 
     return (
         <>
-        <button className="play-btn" onClick={startQuiz}>
+        <button className="quiz-play-btn"  disabled={wordList.length === 0} onClick={startQuiz}>
           Start Quiz
         </button>
         <Dialog


### PR DESCRIPTION
When no words in word list, "Start Quiz" button is disabled with opaque and gray styling. Also shows the same message when no words are in list as the Saved Words tab.

<sub><a href="https://huly.app/guest/knownative?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmU4ZmRlNzQ5YzY4N2Y5NWNlOWY2NzQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWJpZ2FpbGRhd3NvLWtub3duYXRpdmUtNjYzMjgxYjEtODdiZTE2ZDY5OS0yYTZiY2QifQ.1hXuUM3iw0s6d4p9omvzUtV9F-p5mioZn38LnCw_LyA">Huly&reg;: <b>GITHB-115</b></a></sub>