### PR TITLE
DEMO-33: Refactoring the Exit Modal

### DIFF
--- a/src/demo/demo-components/DemoExitModal/DemoExitModal.css
+++ b/src/demo/demo-components/DemoExitModal/DemoExitModal.css
@@ -1,0 +1,3 @@
+.exit-demo-modal-content {
+  margin-bottom: 30px;
+}

--- a/src/demo/demo-components/DemoExitModal/DemoExitModal.jsx
+++ b/src/demo/demo-components/DemoExitModal/DemoExitModal.jsx
@@ -1,30 +1,25 @@
 import './DemoExitModal.css';
 import { useNavigate } from 'react-router-dom';
-import Modal from 'react-bootstrap/Modal';
-import Button from 'react-bootstrap/Button';
+import Modal from '../../../ui-components/Modal/modal';
 
-export default function DemoExitModal({ showExitModal, handleCloseExit }) {
+export default function DemoExitModal({ setShowModal }) {
   const navigate = useNavigate();
   function exitDemo() {
+    setShowModal(false);
     navigate('/');
   }
 
   return (
-    <Modal show={showExitModal} onHide={handleCloseExit} backdrop="static">
-      <Modal.Header closeButton>
-        <Modal.Title>Exit and clear word list?</Modal.Title>
-      </Modal.Header>
-      <Modal.Body>
-        <p>Exiting the demo will remove your saved words. Are you sure you want to proceed?</p>
-      </Modal.Body>
-      <Modal.Footer>
-        <Button variant="secondary" onClick={handleCloseExit}>
-          Go Back
-        </Button>
-        <Button variant="danger" onClick={exitDemo}>
-          Exit
-        </Button>
-      </Modal.Footer>
+    <Modal
+      canCloseOnEscapeKey={true}
+      buttonPrimaryText="Exit"
+      buttonSecondaryText="Go Back"
+      handleSecondaryButtonOnClick={() => setShowModal(false)}
+      handlePrimaryButtonOnClick={exitDemo}
+      hasCloseButton={true}
+      modalTitle={'Exit and clear word list?'}
+      setShowModal={setShowModal}>
+      <p>Exiting the demo will remove your saved words. Are you sure you want to proceed?</p>
     </Modal>
   );
 }

--- a/src/demo/demo-components/DemoExitModal/DemoExitModal.jsx
+++ b/src/demo/demo-components/DemoExitModal/DemoExitModal.jsx
@@ -17,10 +17,10 @@ export default function DemoExitModal({ setShowModal }) {
       handleSecondaryButtonOnClick={() => setShowModal(false)}
       handlePrimaryButtonOnClick={exitDemo}
       hasCloseButton={true}
-      modalTitle={'Exit and clear word list?'}
+      modalTitle={'Exit Demo Session?'}
       setShowModal={setShowModal}>
       <div className="exit-demo-modal-content">
-        <p>Exiting the demo will remove your saved words. Are you sure you want to proceed?</p>
+        <p>Your vocabulary list may disappear after you leave. Are you sure you want to proceed?</p>
       </div>
     </Modal>
   );

--- a/src/demo/demo-components/DemoExitModal/DemoExitModal.jsx
+++ b/src/demo/demo-components/DemoExitModal/DemoExitModal.jsx
@@ -19,7 +19,9 @@ export default function DemoExitModal({ setShowModal }) {
       hasCloseButton={true}
       modalTitle={'Exit and clear word list?'}
       setShowModal={setShowModal}>
-      <p>Exiting the demo will remove your saved words. Are you sure you want to proceed?</p>
+      <div className="exit-demo-modal-content">
+        <p>Exiting the demo will remove your saved words. Are you sure you want to proceed?</p>
+      </div>
     </Modal>
   );
 }

--- a/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
+++ b/src/demo/demo-pages/DemoTextPage/DemoTextPage.jsx
@@ -1,43 +1,46 @@
-import { useState, useEffect, useRef } from "react";
-import { BiLinkExternal } from "react-icons/bi";
-import "./DemoTextPage.css";
-import DemoStudyText from "../../demo-components/DemoStudyText/DemoStudyText";
-import DemoReadText from "../../demo-components/DemoReadText/DemoReadText";
-import DemoTranslateText from "../../demo-components/DemoTranslateText/DemoTranslateText";
-import DemoSavedWordsList from "../../demo-components/DemoSavedWordsList/DemoSavedWordsList";
-import DemoFlashcardForm from "../../demo-components/DemoFlashcardForm/DemoFlashcardForm";
-import DemoInfoSidebar from "../../demo-components/DemoInfoSidebar/DemoInfoSidebar";
-import DemoNav from "../../demo-components/DemoNav/DemoNav";
-import DemoWelcomeModal from "../../demo-components/DemoWelcomeModal/DemoWelcomeModal";
-import DemoExitModal from "../../demo-components/DemoExitModal/DemoExitModal";
+import { useState, useEffect, useRef } from 'react';
+import { BiLinkExternal } from 'react-icons/bi';
+import './DemoTextPage.css';
+import DemoStudyText from '../../demo-components/DemoStudyText/DemoStudyText';
+import DemoReadText from '../../demo-components/DemoReadText/DemoReadText';
+import DemoTranslateText from '../../demo-components/DemoTranslateText/DemoTranslateText';
+import DemoSavedWordsList from '../../demo-components/DemoSavedWordsList/DemoSavedWordsList';
+import DemoFlashcardForm from '../../demo-components/DemoFlashcardForm/DemoFlashcardForm';
+import DemoInfoSidebar from '../../demo-components/DemoInfoSidebar/DemoInfoSidebar';
+import DemoNav from '../../demo-components/DemoNav/DemoNav';
+import DemoWelcomeModal from '../../demo-components/DemoWelcomeModal/DemoWelcomeModal';
+import DemoExitModal from '../../demo-components/DemoExitModal/DemoExitModal';
 // import * as textsAPI from "../../../utilities/texts-api";
 // import * as wordsAPI from "../../../utilities/words-api";
-import { getWordInfo } from "../../../utilities/words-service";
-import DemoLibrary from "../../demo-components/DemoLibrary/DemoLibrary";
+import { getWordInfo } from '../../../utilities/words-service';
+import DemoLibrary from '../../demo-components/DemoLibrary/DemoLibrary';
 //import word from '../../../../models/word'
-import DemoDifficultyTag from "../../demo-components/DemoDifficultyTag/DemoDifficultyTag";
-import demoTexts from '../../demodata'
+import DemoDifficultyTag from '../../demo-components/DemoDifficultyTag/DemoDifficultyTag';
+import demoTexts from '../../demodata';
 
 export default function DemoTextPage({ getText, updateText }) {
-
   // --- DISPLAY STATE VALUES ---
-  const [activeTab, setActiveTab] = useState("read");
+  const [activeTab, setActiveTab] = useState('read');
   const [sidebarCategory, setSidebarCategory] = useState(null);
   const [expandedSidebar, setExpandedSidebar] = useState(false);
 
   //-- TEXT DIFFICULTY STATE VALUES--
   const [textSelection, setTextSelection] = useState(
-    (localStorage.getItem("textSelection") === null) ? "beginner" : localStorage.getItem("textSelection")
+    localStorage.getItem('textSelection') === null
+      ? 'beginner'
+      : localStorage.getItem('textSelection')
   );
   const [text, setText] = useState(
-    (localStorage.getItem("text") === null) ? demoTexts.beginner : JSON.parse(localStorage.getItem("text"))
+    localStorage.getItem('text') === null
+      ? demoTexts.beginner
+      : JSON.parse(localStorage.getItem('text'))
   );
 
   // --- SAVED WORDS ---
   const [localSavedWords, setLocalSavedWords] = useState(
-    JSON.parse(localStorage.getItem("stringifiedWords") === null)
+    JSON.parse(localStorage.getItem('stringifiedWords') === null)
       ? []
-      : JSON.parse(localStorage.getItem("stringifiedWords"))
+      : JSON.parse(localStorage.getItem('stringifiedWords'))
   );
   // const [savedWords, setSavedWords] = useState([]);
 
@@ -54,14 +57,16 @@ export default function DemoTextPage({ getText, updateText }) {
   const [isDemoWelcomeModalOpen, setDemoWelcomeModalOpen] = useState(true);
   //const [demoWelcomeModalData, setDemoWelcomeModalData] = useState(null);
   const [welcomeModalComplete, setWelcomeModalComplete] = useState(
-    (localStorage.getItem("welcomeModalComplete") === null) ? false : JSON.parse(localStorage.getItem("welcomeModalComplete"))
-  )
+    localStorage.getItem('welcomeModalComplete') === null
+      ? false
+      : JSON.parse(localStorage.getItem('welcomeModalComplete'))
+  );
 
   const handleCloseDemoWelcomeModal = () => {
-    setWelcomeModalComplete(true)
-    setDemoWelcomeModalOpen(false)
-    localStorage.setItem("welcomeModalComplete", 'true')
-  }
+    setWelcomeModalComplete(true);
+    setDemoWelcomeModalOpen(false);
+    localStorage.setItem('welcomeModalComplete', 'true');
+  };
 
   const handleWelcomeModalSubmit = (data) => {
     //setDemoWelcomeModalData(data);
@@ -73,36 +78,26 @@ export default function DemoTextPage({ getText, updateText }) {
   const blurRef = useRef(null);
 
   // --- Text Selection Side Effects---
-  useEffect(
-    () => {
-      setText(demoTexts[textSelection])
-      localStorage.setItem(
-        "text",
-        JSON.stringify(demoTexts[textSelection])
-      )
+  useEffect(() => {
+    setText(demoTexts[textSelection]);
+    localStorage.setItem('text', JSON.stringify(demoTexts[textSelection]));
 
-      localStorage.setItem("textSelection", textSelection)
-    },
-    [textSelection]
-  )
+    localStorage.setItem('textSelection', textSelection);
+  }, [textSelection]);
 
   useEffect(
     function () {
       function setLocalStorage() {
-        localStorage.setItem(
-          "stringifiedWords",
-          JSON.stringify(localSavedWords)
-        );
+        localStorage.setItem('stringifiedWords', JSON.stringify(localSavedWords));
       }
       setLocalStorage();
     },
     [localSavedWords]
   );
 
-
   // --- SAVED WORDS RELATED FUNCTIONS ---
   function generateID() {
-    const savedWords = JSON.parse(localStorage.getItem("stringifiedWords"));
+    const savedWords = JSON.parse(localStorage.getItem('stringifiedWords'));
     if (savedWords.length === 0) {
       return 0;
     } else {
@@ -111,23 +106,23 @@ export default function DemoTextPage({ getText, updateText }) {
   }
 
   function saveWord(word) {
-    const savedWords = JSON.parse(localStorage.getItem("stringifiedWords"));
+    const savedWords = JSON.parse(localStorage.getItem('stringifiedWords'));
     const wordToSave = getWordInfo(word);
     wordToSave._id = generateID();
     setLocalSavedWords([...savedWords, wordToSave]);
-    setActiveWord("");
+    setActiveWord('');
     setShowPopup(false);
   }
 
   function deleteWord(word) {
-    const savedWords = JSON.parse(localStorage.getItem("stringifiedWords"));
+    const savedWords = JSON.parse(localStorage.getItem('stringifiedWords'));
     const filteredWords = savedWords.filter((item) => item._id !== word._id);
     setLocalSavedWords([...filteredWords]);
   }
 
   /* FUNCTION ALTERED to allow for users to have meaning, term, and reading updated after form submission.*/
   function updateWord(word, inputtedMeaning, inputtedTerm, inputtedReading) {
-    const savedWords = JSON.parse(localStorage.getItem("stringifiedWords"));
+    const savedWords = JSON.parse(localStorage.getItem('stringifiedWords'));
     for (let k in savedWords) {
       if (savedWords[k]._id === word._id) {
         savedWords[k].meaning = inputtedMeaning;
@@ -168,20 +163,16 @@ export default function DemoTextPage({ getText, updateText }) {
   // blurs background text when flashcard game in progress
   const blurText = (isActive) => {
     if (isActive) {
-      blurRef.current.style.filter = "blur(4px)";
+      blurRef.current.style.filter = 'blur(4px)';
     } else {
-      blurRef.current.removeAttribute("style");
+      blurRef.current.removeAttribute('style');
     }
   };
 
-
   return !text ? (
-    "Loading ..."
+    'Loading ...'
   ) : (
-    <main
-      className={`TextPage page ${expandedSidebar ? "expanded-sidebar" : "collapsed-sidebar"
-        }`}
-    >
+    <main className={`TextPage page ${expandedSidebar ? 'expanded-sidebar' : 'collapsed-sidebar'}`}>
       <nav className="side-nav">
         <DemoNav
           expandSidebar={expandSidebar}
@@ -195,7 +186,7 @@ export default function DemoTextPage({ getText, updateText }) {
       {/* Conditional rendering, dependent on the values of expandedSidbar and sidebarCategory, that will determine if the sidebar is displayed and what content is displayed. */}
 
       <aside className="sidebar">
-        {sidebarCategory === "savedwords-tooltip" && (
+        {sidebarCategory === 'savedwords-tooltip' && (
           <DemoSavedWordsList
             savedWords={localSavedWords}
             updateWord={updateWord}
@@ -203,7 +194,7 @@ export default function DemoTextPage({ getText, updateText }) {
             handleBackArrowClick={handleBackArrowClick}
           />
         )}
-        {sidebarCategory === "flashcards-tooltip" && (
+        {sidebarCategory === 'flashcards-tooltip' && (
           <DemoFlashcardForm
             expandSidebar={expandSidebar}
             changeSidebarCategory={changeSidebarCategory}
@@ -212,13 +203,13 @@ export default function DemoTextPage({ getText, updateText }) {
             blurText={blurText}
           />
         )}
-        {sidebarCategory === "info-tooltip" && (
+        {sidebarCategory === 'info-tooltip' && (
           <DemoInfoSidebar
             changeSidebarCategory={changeSidebarCategory}
             handleBackArrowClick={handleBackArrowClick}
           />
         )}
-        {sidebarCategory === "library-tooltip" && (
+        {sidebarCategory === 'library-tooltip' && (
           <DemoLibrary
             handleBackArrowClick={handleBackArrowClick}
             textSelection={textSelection}
@@ -229,25 +220,21 @@ export default function DemoTextPage({ getText, updateText }) {
         )}
       </aside>
 
-
       <section className="main-area" ref={topRef}>
         <div className="tabs sticky-fade">
           <button
-            className={`tab-btn ${activeTab === "read" ? "active" : ""}`}
-            onClick={() => handleTabClick("read")}
-          >
+            className={`tab-btn ${activeTab === 'read' ? 'active' : ''}`}
+            onClick={() => handleTabClick('read')}>
             Read
           </button>
           <button
-            className={`tab-btn ${activeTab === "study" ? "active" : ""}`}
-            onClick={() => handleTabClick("study")}
-          >
+            className={`tab-btn ${activeTab === 'study' ? 'active' : ''}`}
+            onClick={() => handleTabClick('study')}>
             Study
           </button>
           <button
-            className={`tab-btn ${activeTab === "translate" ? "active" : ""}`}
-            onClick={() => handleTabClick("translate")}
-          >
+            className={`tab-btn ${activeTab === 'translate' ? 'active' : ''}`}
+            onClick={() => handleTabClick('translate')}>
             Translate
           </button>
         </div>
@@ -258,24 +245,14 @@ export default function DemoTextPage({ getText, updateText }) {
               <h1 className="textpage-heading-title zh">{text.title}</h1>
               <article className="textpage-difficulty-tag">
                 <DemoDifficultyTag textSelection={textSelection} />
-                <a
-                  href={text.source}
-                  className="link-view-source"
-                  target="_blank"
-                  rel="noreferrer"
-                >
+                <a href={text.source} className="link-view-source" target="_blank" rel="noreferrer">
                   View Source <BiLinkExternal />
                 </a>
               </article>
-
             </div>
           </div>
 
-          <div
-            id="study"
-            className={`study-container ${activeTab === "study" ? "active" : ""
-              }`}
-          >
+          <div id="study" className={`study-container ${activeTab === 'study' ? 'active' : ''}`}>
             <div className="Text study-content">
               {text ? (
                 <DemoStudyText
@@ -289,50 +266,37 @@ export default function DemoTextPage({ getText, updateText }) {
                   setShowPopup={setShowPopup}
                 />
               ) : (
-                "Loading text"
+                'Loading text'
               )}
             </div>
           </div>
 
-          <div
-            id="read"
-            className={`read-container ${activeTab === "read" ? "active" : ""}`}
-          >
-            <div className="Text">
-              {text ? <DemoReadText text={text} /> : "Loading text"}
-            </div>
+          <div id="read" className={`read-container ${activeTab === 'read' ? 'active' : ''}`}>
+            <div className="Text">{text ? <DemoReadText text={text} /> : 'Loading text'}</div>
           </div>
 
           <div
             id="translate"
-            className={`translate-container ${activeTab === "translate" ? "active" : ""
-              }`}
-          >
-            <div className="Text">
-              {text ? <DemoTranslateText text={text} /> : "Loading text"}
-            </div>
+            className={`translate-container ${activeTab === 'translate' ? 'active' : ''}`}>
+            <div className="Text">{text ? <DemoTranslateText text={text} /> : 'Loading text'}</div>
           </div>
         </div>
       </section>
       <div id="exit-modal">
-        {
-          <DemoExitModal
-            showExitModal={showExitModal}
-            handleCloseExit={handleCloseExit}
-          />
-        }
+        {showExitModal ? <DemoExitModal setShowModal={setShowExitModal} /> : null}
       </div>
 
-      {welcomeModalComplete ? ""
-        : (<DemoWelcomeModal
+      {welcomeModalComplete ? (
+        ''
+      ) : (
+        <DemoWelcomeModal
           isOpen={isDemoWelcomeModalOpen}
           onSubmit={handleWelcomeModalSubmit}
           onClose={handleCloseDemoWelcomeModal}
           textSelection={textSelection}
           setTextSelection={setTextSelection}
-        />)
-      }
-
+        />
+      )}
     </main>
   );
 }


### PR DESCRIPTION
### Describe your changes:

This PR refactors the exit demo modal to use the reusable modal component, making it consistent with the other two modals (screensize warning and edit word modal) 

Before:
<img width="400" src="https://github.com/user-attachments/assets/e5960acc-b95e-46ff-854f-e17713f94d9c">

After:
<img width="400" src="https://github.com/user-attachments/assets/fcb49abb-357f-4969-9441-bfba09a8e025">

### Issue ticket number and link:

https://huly.app/workbench/knownative/tracker/DEMO-33

### Notes:
None

### How to test:
Demo Page:
> Click the exit button in the bottom left of the screen
> Verify the exit modal pops up
> Verify the "X" button closes the modal and remains on the demo page
> Verify hitting the ESC key closes the modal and remains on the demo page
> Verify clicking the "Go Back" button closes the modal and remains on the demo page
> Verify clicking the "Exit" button closes the modal and navigates to the landing page