### PR TITLE
Add a Text Import Form

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -11,6 +11,7 @@ import DashboardPage from './KnowNativePage/DashboardPage/DashboardPage';
 import AppProvider from './contexts/AppProvider';
 import SignupSuccessful from './KnowNativePage/SignupSuccessful/SignupSuccessful';
 import LoginSuccessful from './KnowNativePage/LoginSuccessful/LoginSuccessful';
+import AddTextPage from './KnowNativePage/AddTextPage/AddTextPage';
 
 function App() {
   return (
@@ -25,6 +26,7 @@ function App() {
           <Route path="/signup" element={<SignupPage />} />
           <Route path="/login-success" element={<LoginSuccessful />} />
           <Route path="/signup-success" element={<SignupSuccessful />} />
+          <Route path="/add-text" element={<AddTextPage />} />
           <Route path="/*" element={<LandingPage />} />
         </Routes>
       </main>

--- a/client/src/KnowNativePage/AddTextPage/AddTextPage.jsx
+++ b/client/src/KnowNativePage/AddTextPage/AddTextPage.jsx
@@ -1,0 +1,180 @@
+import React, { useState } from 'react';
+import { useAuthContext } from '../../contexts/Auth/AuthProvider';
+import { Link, useNavigate } from 'react-router-dom';
+import FormInput from '../../LandingPages/components/Forms/FormInput/FormInput';
+import Button from '../../ui-components/Button/button';
+import './AddTextPage.scss';
+
+export default function AddTextPage() {
+  const [formData, setFormData] = useState({
+    source: '',
+    title: '',
+    content: ''
+  });
+
+  const { user, setUser } = useAuthContext();
+  const navigate = useNavigate();
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData({
+      ...formData,
+      [name]: value
+    });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    // Handle form submission logic here
+    // Example:
+    // const response = await fetch('/api/texts', {
+    //   method: 'POST',
+    //   headers: {
+    //     'Content-Type': 'application/json',
+    //     Authorization: `Bearer ${user.token}`
+    //   },
+    //   body: JSON.stringify(formData)
+    // });
+    // const data = await response.json();
+    // if (response.ok) {
+    //   navigate('/texts');
+    // } else {
+    //   console.error('Error adding text:', data.error);
+    // }
+
+    // For now, let's simulate the success and redirect to the dashboard page
+    navigate('/dashboard');
+    console.log('Form submitted:', formData);
+  };
+
+  async function handleLogOut() {
+    try {
+      await authService.logOut();
+      setUser(null);
+      navigate('/');
+    } catch (error) {
+      console.error(error.message);
+      alert('There was an issue logging out. Please try again.');
+    }
+  }
+
+  return user ? (
+    <div className="dashboard">
+      <div className="dashboard__side-nav">
+        <div className="dashboard__side-nav-links-container">
+          <a href="../" className="dashboard__logo-container">
+            <img src="/images/square-logo.png" alt="KnowNative logo." className="dashboard__logo" />
+            <h4>KnowNative</h4>
+          </a>
+          <ul className="dashboard__nav-links">
+            <li className="dasboard__nav-item">
+              <a className="dashboard__link" href="/dashboard">
+                Dashboard
+              </a>
+            </li>
+            <li className="dasboard__nav-item">
+              <a className="dashboard__link" href="/">
+                Cards
+              </a>
+            </li>
+            <li className="dasboard__nav-item">
+              <a className="dashboard__link" href="/">
+                Library
+              </a>
+            </li>
+            <li className="dasboard__nav-item">
+              <a className="dashboard__link" href="/">
+                Progress
+              </a>
+            </li>
+            <li className="dasboard__nav-item">
+              <a className="dashboard__link" href="/">
+                Resources
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div className="dashboard__nav-footer">
+          <ul className="dashboard__nav-links">
+            <li className="dasboard__nav-item">
+              <button className="dashboard__link" onClick={handleLogOut}>
+                Logout
+              </button>
+            </li>
+            <li className="dasboard__nav-item">
+              <a className="dashboard__link" href="/">
+                GitHub
+              </a>
+            </li>
+            <li className="dasboard__nav-item">
+              <a className="dashboard__link" href="/">
+                Contact Us
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div className="dashboard__main">
+        <div className="dashboard__user-info">
+          <button className='dashboard__user-dropdown-options'>
+            <p className='dashboard__user-name'>{user.username}</p>
+            <img
+              className="dashboard__user-profile-pic"
+              src="/images/square-logo.png"
+              alt="User profile picture."
+            />
+            <p className="dashboard__user-dropdown-icon">┕</p>
+          </button>
+        </div>
+        <div className="add-text-form">
+          <h1 className='add-text-form__title'>Import Text</h1>
+          <form onSubmit={handleSubmit}>
+            <FormInput
+                label="Title"
+                htmlFor="title"
+                id="title"
+                name="title"
+                value={formData.title}
+                onChange={handleChange}
+                required
+              />
+            <FormInput
+              label="Source"
+              htmlFor="source"
+              id="source"
+              name="source"
+              value={formData.source}
+              onChange={handleChange}
+              required
+            />
+            <FormInput
+              label="Content"
+              htmlFor="content"
+              id="content"
+              name="content"
+              value={formData.content}
+              onChange={handleChange}
+              required
+              as="textarea"
+            />
+            <div className="add-text-form__buttons">
+                <Button
+                className="test"
+                buttonText="Submit"
+                buttonOnClickFunc={handleSubmit}
+                buttonVariant="primary"
+                />
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  ) : (
+    <div>
+      <p>
+        User not logged in. Please log in <Link to="/login">here</Link>.
+      </p>
+    </div>
+  );
+}

--- a/client/src/KnowNativePage/AddTextPage/AddTextPage.scss
+++ b/client/src/KnowNativePage/AddTextPage/AddTextPage.scss
@@ -1,0 +1,19 @@
+.add-text-form {
+    display: grid;
+    width: 55vw;
+    max-width: 820px;
+    margin-inline: auto;
+
+    &__title {
+        color: var(--darkest)
+    }
+
+    &__buttons {
+        margin-top: 22px;
+    }
+
+}
+
+.input-box__input-container {
+    width: 100%;
+}

--- a/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
+++ b/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
@@ -151,7 +151,11 @@ export default function DashboardPage() {
           </div>
         </div>
         <div className="dashboard dashboard__card-buttons">
-          <button className="dashboard__card-buttons--add-item">+ Add text</button>
+          <button 
+            className="dashboard__card-buttons--add-item" 
+            onClick={() => navigate('/add-text')}>
+            + Add text
+          </button>
           <button className="dashboard__card-buttons--view-all">View all</button>
         </div>
       </div>


### PR DESCRIPTION
When users click on the dashboard button "+ Add Text", they'll be redirected to `AddTextPage.jsx` so that they can import a text using copy and paste.

The Import Text form allows the user to enter the following fields:

- Title
- Source
- Content.

The form will later need to be updated according to wireframe designs and future features such as tags and status.

### Integration of `AddTextPage`:

* [`client/src/App.jsx`](diffhunk://#diff-51b002bf85fbd146b38871b89ba0d41c2bead37756295748c67206aac23ddc9aR14): Imported `AddTextPage` and added a new route for it in the `App` component.

### Creation of `AddTextPage` component:

* [`client/src/KnowNativePage/AddTextPage/AddTextPage.jsx`](diffhunk://#diff-e0cc514d802ebed37cd7fdbe11ad4672c2a9d96591cf90d703644d9a3d59af5cR1-R180): Created the `AddTextPage` component.
* [`client/src/KnowNativePage/AddTextPage/AddTextPage.scss`](diffhunk://#diff-6579cac983c5261ce3f90eb4092e9570636df15d9a2242a4f59b80177f8cb570R1-R19): Added styles specific to the `AddTextPage` component.

### Dashboard integration:

* [`client/src/KnowNativePage/DashboardPage/DashboardPage.jsx`](diffhunk://#diff-09d11ac97e6cfac621bcda91f92d9dd9a0b7178f94d77abf279ac0a2b51431f6L154-R158): Updated the dashboard to include a button that navigates to the `AddTextPage`.