### PR TITLE
Update textSchema to allow text imports with existing Titles

### DIFF
--- a/server/models/text.js
+++ b/server/models/text.js
@@ -3,7 +3,7 @@ const { Schema, model } = require("mongoose");
 const textSchema = new Schema(
   {
     user: { type: Schema.Types.ObjectId, ref: "User", required: true },
-    title: { type: String, required: true, unique: true, trim: true },
+    title: { type: String, required: true, trim: true },
     source: { type: String },
     content: { type: String },
     // level needs to be added once we can classify a text correctly upon upload


### PR DESCRIPTION
It worked!

After dropping the `title` index from the MongoDB collection and removing the `unique: true` property on `textSchema`, users can now import texts with existing titles. 