### PR TITLE
Fix UI Bug: visibility flickers in password input field in login form

### DIFF
--- a/client/src/LandingPages/components/Forms/FormInput/FormInput.jsx
+++ b/client/src/LandingPages/components/Forms/FormInput/FormInput.jsx
@@ -43,7 +43,6 @@ const FormInput = (props) => {
         <span
           className="input-box__icon material-symbols-outlined"
           onClick={() => setShowPassword(!showPassword)}>
-          {showPassword ? 'visibility_off' : 'visibility'}
         </span>
       ) : null}
 


### PR DESCRIPTION
The bug was found in FormInput.jsx; it looks like the span tag responsible for all password visibility functionality was causing the issue. Simply removing it solved the problem.