### PR TITLE
SIGNUP #6: Implement Password Flow & Alter Password Design

### DIFF
--- a/client/src/LandingPages/components/Forms/PasswordValidation.jsx
+++ b/client/src/LandingPages/components/Forms/PasswordValidation.jsx
@@ -1,8 +1,7 @@
 import { FaExclamationTriangle, FaCheckCircle } from "react-icons/fa";
 
 function PasswordValidation({ password, confirmPassword = null, isConfirmField = false }) {
-  const hasTypedPassword = password.length > 0;
-  const hasTypedConfirmPassword = isConfirmField ? confirmPassword.length > 0 : null;
+  const hasTypedConfirmPassword = confirmPassword?.length;
 
   const validations = !isConfirmField ? [
     {
@@ -28,59 +27,49 @@ function PasswordValidation({ password, confirmPassword = null, isConfirmField =
   ] : [
     {
       test: confirmPassword === password,
-      message: 'Passwords must match.'
+      message: 'Passwords do not match.'
     }
   ];
 
-  if (!isConfirmField) {
-    return (
-      <ul className="password-validation">
-        {validations.map((validation, index) => (
+  return (
+    <ul className="password-validation">
+      {validations.map((validation, index) => {
+        const isValid = validation.test;
+        const shouldShow = (!isConfirmField) || (isConfirmField && hasTypedConfirmPassword && !isValid);
+
+        return (
           <li
             key={index}
-            style={{
-              color: hasTypedPassword ? (validation.test ? "var(--green-lt)" : "var(--red-poppy)") : "#556163"
-            }}
-          >
-            {validation.test ? (
-              <FaCheckCircle
-                style={hasTypedPassword ? { color: "var(--green-lt)" } : { color: "transparent" }}
-                title="Test passed" />
+            style={shouldShow ? (
+              {
+                color: "#556163"
+              }
             ) : (
-              <FaExclamationTriangle
-                style={hasTypedPassword ? { color: "var(--red-poppy)" } : { color: "transparent" }}
-                title={validation.message} />
+              {
+                display: "none"
+              }
             )}
+          >
+            {shouldShow ? (
+              isValid ? (
+                <FaCheckCircle
+                  title="Test passed"
+                  style={{ color: "#197D00" }}
+                />
+              ) : (
+                <FaExclamationTriangle
+                  title={validation.message}
+                  style={{ color: "#962828" }}
+                />
+              )
+            ) : <FaExclamationTriangle style={{ color: "transparent" }} />
+            }
             {validation.message}
           </li>
-        ))}
-      </ul>
-    );
-  } else {
-    return (
-      <ul className="password-validation">
-        {validations.map((validation, index) => (
-          <li
-            key={index}
-            style={{
-              color: hasTypedConfirmPassword ? (validation.test ? "var(--green-lt)" : "var(--red-poppy)") : "#556163"
-            }}
-          >
-            {validation.test ? (
-              <FaCheckCircle
-                style={hasTypedConfirmPassword ? { color: "var(--green-lt)" } : { color: "transparent" }}
-                title="Test passed" />
-            ) : (
-              <FaExclamationTriangle
-                style={hasTypedConfirmPassword ? { color: "var(--red-poppy)" } : { color: "transparent" }}
-                title={validation.message} />
-            )}
-            {validation.message}
-          </li>
-        ))}
-      </ul>
-    );
-  };
-};
+        );
+      })}
+    </ul>
+  );
+}
 
 export default PasswordValidation;

--- a/client/src/LandingPages/components/Forms/PasswordValidation.jsx
+++ b/client/src/LandingPages/components/Forms/PasswordValidation.jsx
@@ -1,35 +1,44 @@
 import { FaExclamationTriangle, FaCheckCircle } from "react-icons/fa";
 
 function PasswordValidation({ password }) {
-    const validations = [
-      {
-        test: password.length >= 8 && password.length <= 32,
-        message: 'The password must be 8-32 characters long.',
-      },
-      {
-        test: /[A-Z]/.test(password),
-        message: 'The password must contain at least one uppercase letter.',
-      },
-      {
-        test: /[a-z]/.test(password),
-        message: 'The password must contain at least one lowercase letter.',
-      },
-      {
-        test: /\d/.test(password),
-        message: 'The password must include at least one digit (0-9).',
-      },
-      {
-        test: /[@$!%*?&]/.test(password),
-        message: 'The password must contain at least one special character (!, @, #, $).',
-      },
-    ];
+  const hasTyped = password.length > 0;
+
+  const validations = [
+    {
+      test: password.length >= 8 && password.length <= 32,
+      message: 'The password must be 8-32 characters long.',
+    },
+    {
+      test: /[A-Z]/.test(password),
+      message: 'The password must contain at least one uppercase letter.',
+    },
+    {
+      test: /[a-z]/.test(password),
+      message: 'The password must contain at least one lowercase letter.',
+    },
+    {
+      test: /\d/.test(password),
+      message: 'The password must include at least one digit (0-9).',
+    },
+    {
+      test: /[@$!%*?&]/.test(password),
+      message: 'The password must contain at least one special character (!, @, #, $).',
+    },
+  ];
 
   return (
     <ul className="password-validation">
       {validations.map((validation, index) => (
         <li key={index}>
-          {validation.test ? <FaCheckCircle style={{color: "#556163"}} title="Test passed"/> 
-          : <FaExclamationTriangle style={{color: "red"}} title={validation.message}/>} 
+          {validation.test ? (
+            <FaCheckCircle
+              style={hasTyped ? { color: "#556163" } : { color: "transparent" }}
+              title="Test passed" />
+          ) : (
+            <FaExclamationTriangle
+              style={hasTyped ? { color: "red" } : { color: "transparent" }}
+              title={validation.message} />
+          )}
           {validation.message}
         </li>
       ))}

--- a/client/src/LandingPages/components/Forms/PasswordValidation.jsx
+++ b/client/src/LandingPages/components/Forms/PasswordValidation.jsx
@@ -1,9 +1,10 @@
 import { FaExclamationTriangle, FaCheckCircle } from "react-icons/fa";
 
-function PasswordValidation({ password }) {
-  const hasTyped = password.length > 0;
+function PasswordValidation({ password, confirmPassword = null, isConfirmField = false }) {
+  const hasTypedPassword = password.length > 0;
+  const hasTypedConfirmPassword = isConfirmField ? confirmPassword.length > 0 : null;
 
-  const validations = [
+  const validations = !isConfirmField ? [
     {
       test: password.length >= 8 && password.length <= 32,
       message: 'The password must be 8-32 characters long.',
@@ -24,31 +25,62 @@ function PasswordValidation({ password }) {
       test: /[@$!%*?&]/.test(password),
       message: 'The password must contain at least one special character (!, @, #, $).',
     },
+  ] : [
+    {
+      test: confirmPassword === password,
+      message: 'Passwords must match.'
+    }
   ];
 
-  return (
-    <ul className="password-validation">
-      {validations.map((validation, index) => (
-        <li
-          key={index}
-          style={{
-            color: hasTyped ? (validation.test ? "var(--green-lt)" : "var(--red-poppy)") : "#556163"
-          }}
-        >
-          {validation.test ? (
-            <FaCheckCircle
-              style={hasTyped ? { color: "var(--green-lt)" } : { color: "transparent" }}
-              title="Test passed" />
-          ) : (
-            <FaExclamationTriangle
-              style={hasTyped ? { color: "var(--red-poppy)" } : { color: "transparent" }}
-              title={validation.message} />
-          )}
-          {validation.message}
-        </li>
-      ))}
-    </ul>
-  );
+  if (!isConfirmField) {
+    return (
+      <ul className="password-validation">
+        {validations.map((validation, index) => (
+          <li
+            key={index}
+            style={{
+              color: hasTypedPassword ? (validation.test ? "var(--green-lt)" : "var(--red-poppy)") : "#556163"
+            }}
+          >
+            {validation.test ? (
+              <FaCheckCircle
+                style={hasTypedPassword ? { color: "var(--green-lt)" } : { color: "transparent" }}
+                title="Test passed" />
+            ) : (
+              <FaExclamationTriangle
+                style={hasTypedPassword ? { color: "var(--red-poppy)" } : { color: "transparent" }}
+                title={validation.message} />
+            )}
+            {validation.message}
+          </li>
+        ))}
+      </ul>
+    );
+  } else {
+    return (
+      <ul className="password-validation">
+        {validations.map((validation, index) => (
+          <li
+            key={index}
+            style={{
+              color: hasTypedConfirmPassword ? (validation.test ? "var(--green-lt)" : "var(--red-poppy)") : "#556163"
+            }}
+          >
+            {validation.test ? (
+              <FaCheckCircle
+                style={hasTypedConfirmPassword ? { color: "var(--green-lt)" } : { color: "transparent" }}
+                title="Test passed" />
+            ) : (
+              <FaExclamationTriangle
+                style={hasTypedConfirmPassword ? { color: "var(--red-poppy)" } : { color: "transparent" }}
+                title={validation.message} />
+            )}
+            {validation.message}
+          </li>
+        ))}
+      </ul>
+    );
+  };
 };
 
 export default PasswordValidation;

--- a/client/src/LandingPages/components/Forms/PasswordValidation.jsx
+++ b/client/src/LandingPages/components/Forms/PasswordValidation.jsx
@@ -29,14 +29,19 @@ function PasswordValidation({ password }) {
   return (
     <ul className="password-validation">
       {validations.map((validation, index) => (
-        <li key={index}>
+        <li
+          key={index}
+          style={{
+            color: hasTyped ? (validation.test ? "var(--green-lt)" : "var(--red-poppy)") : "#556163"
+          }}
+        >
           {validation.test ? (
             <FaCheckCircle
-              style={hasTyped ? { color: "#556163" } : { color: "transparent" }}
+              style={hasTyped ? { color: "var(--green-lt)" } : { color: "transparent" }}
               title="Test passed" />
           ) : (
             <FaExclamationTriangle
-              style={hasTyped ? { color: "red" } : { color: "transparent" }}
+              style={hasTyped ? { color: "var(--red-poppy)" } : { color: "transparent" }}
               title={validation.message} />
           )}
           {validation.message}

--- a/client/src/LandingPages/components/LandingPageSignupModal/SignupModal.jsx
+++ b/client/src/LandingPages/components/LandingPageSignupModal/SignupModal.jsx
@@ -78,9 +78,6 @@ const SignupModal = ({ setShowModal }) => {
 
   const handleChange = (e) => {
     setInputValue({ ...inputValue, [e.target.name]: e.target.value });
-    if (e.target.name === 'password') {
-      setIsPasswordTyping(true);
-    }
   };
 
   const handleBlur = (e) => {
@@ -88,6 +85,10 @@ const SignupModal = ({ setShowModal }) => {
     const fieldValue = e.target.value;
     const newErrors = validateInput({ ...inputValue, [fieldName]: fieldValue });
     setInputErrors({ ...inputErrors, [fieldName]: newErrors[fieldName] });
+  };
+
+  const handlePasswordFocus = () => {
+    setIsPasswordTyping(true);
   };
 
   async function handleSubmit(evt) {
@@ -112,61 +113,61 @@ const SignupModal = ({ setShowModal }) => {
       setShowModal={setShowModal}
       hasCloseButton={true}
       hasCustomButtons={true}>
-        <main className='signup-page__main'>
-          <section className="signup-page__container">
-            <h1 className="signup-page__title">Create Your Knownative Account</h1>
-            {errorMsg && (
-              <div className="signup-page__error-message">
-                <h5>
-                  <em>{errorMsg}</em>
-                </h5>
-              </div>
-            )}
-            <form className="signup-page__form" onSubmit={handleSubmit}>
-              {formFields.map((input, idx) => (
-                <React.Fragment key={idx}>
-                  <FormInput
-                    key={idx}
-                    {...input}
-                    value={inputValue[input.name]}
-                    onChange={handleChange}
-                    errorInputMessage={inputErrors[input.name]}
-                    handleBlur={handleBlur}
-                  />
-                  {input.name === 'password' && (
-                    <div
-                      className={`password-validation__wrapper 
-                        ${
-                          isPasswordTyping
-                            ? 'password-validation__wrapper--visible'
-                            : 'password-validation__wrapper--hidden'
-                        }`}>
-                      <PasswordValidation password={inputValue.password} />
-                    </div>
-                  )}
-                </React.Fragment>
-              ))}
-              <button className="signup-page__button signup-page__button-email" type="submit">
-                Sign Up
-              </button>
-              <div className="signup-page__separator">
-                <span className="signup-page__separator--text">OR</span>
-              </div>
-              <button className="signup-page__button signup-page__button-google">
-                <img
-                  className="signup-page__button-google--icon"
-                  src="../../../public/images/google-icon.png"
-                  alt="google sign in"
+      <main className='signup-page__main'>
+        <section className="signup-page__container">
+          <h1 className="signup-page__title">Create Your Knownative Account</h1>
+          {errorMsg && (
+            <div className="signup-page__error-message">
+              <h5>
+                <em>{errorMsg}</em>
+              </h5>
+            </div>
+          )}
+          <form className="signup-page__form" onSubmit={handleSubmit}>
+            {formFields.map((input, idx) => (
+              <React.Fragment key={idx}>
+                <FormInput
+                  key={idx}
+                  {...input}
+                  value={inputValue[input.name]}
+                  onChange={handleChange}
+                  errorInputMessage={inputErrors[input.name]}
+                  handleBlur={handleBlur}
+                  onFocus={input.name === 'password' ? handlePasswordFocus : undefined}
                 />
-                Sign up with Google
-              </button>
-              <div>
-                <Link to="/login" className="signup-page__login-link">
-                  Already have an account? Log in
-                </Link>
-              </div>
-            </form>
-          </section>
+                {input.name === 'password' && (
+                  <div
+                    className={`password-validation__wrapper 
+                        ${isPasswordTyping
+                        ? 'password-validation__wrapper--visible'
+                        : 'password-validation__wrapper--hidden'
+                      }`}>
+                    <PasswordValidation password={inputValue.password} />
+                  </div>
+                )}
+              </React.Fragment>
+            ))}
+            <button className="signup-page__button signup-page__button-email" type="submit">
+              Sign Up
+            </button>
+            <div className="signup-page__separator">
+              <span className="signup-page__separator--text">OR</span>
+            </div>
+            <button className="signup-page__button signup-page__button-google">
+              <img
+                className="signup-page__button-google--icon"
+                src="../../../public/images/google-icon.png"
+                alt="google sign in"
+              />
+              Sign up with Google
+            </button>
+            <div>
+              <Link to="/login" className="signup-page__login-link">
+                Already have an account? Log in
+              </Link>
+            </div>
+          </form>
+        </section>
       </main>
     </Modal>
   );

--- a/client/src/LandingPages/components/LandingPageSignupModal/SignupModal.jsx
+++ b/client/src/LandingPages/components/LandingPageSignupModal/SignupModal.jsx
@@ -21,6 +21,7 @@ const SignupModal = ({ setShowModal }) => {
   const [inputErrors, setInputErrors] = useState({});
   const [errorMsg, setErrorMsg] = useState('');
   const [isPasswordTyping, setIsPasswordTyping] = useState(false);
+  const [isConfirmPasswordTyping, setIsConfirmPasswordTyping] = useState(false);
   const navigate = useNavigate();
   const { setUser } = useAuthContext();
 
@@ -91,6 +92,10 @@ const SignupModal = ({ setShowModal }) => {
     setIsPasswordTyping(true);
   };
 
+  const handleConfirmPasswordFocus = () => {
+    setIsConfirmPasswordTyping(true);
+  };
+
   async function handleSubmit(evt) {
     evt.preventDefault();
     try {
@@ -133,7 +138,9 @@ const SignupModal = ({ setShowModal }) => {
                   onChange={handleChange}
                   errorInputMessage={inputErrors[input.name]}
                   handleBlur={handleBlur}
-                  onFocus={input.name === 'password' ? handlePasswordFocus : undefined}
+                  onFocus={input.name === 'password' ? handlePasswordFocus
+                    : input.name === 'confirmPassword' ? handleConfirmPasswordFocus
+                      : undefined}
                 />
                 {input.name === 'password' && (
                   <div
@@ -145,6 +152,22 @@ const SignupModal = ({ setShowModal }) => {
                     <PasswordValidation password={inputValue.password} />
                   </div>
                 )}
+                {
+                  input.name === 'confirmPassword' && (
+                    <div
+                      className={`password-validation__wrapper 
+                        ${isConfirmPasswordTyping
+                          ? 'password-validation__wrapper--visible'
+                          : 'password-validation__wrapper--hidden'
+                        }`}>
+                      <PasswordValidation
+                        password={inputValue.password}
+                        confirmPassword={inputValue.confirmPassword}
+                        isConfirmField={true}
+                      />
+                    </div>
+                  )
+                }
               </React.Fragment>
             ))}
             <button className="signup-page__button signup-page__button-email" type="submit">


### PR DESCRIPTION
As per the issue...

1. Upon entering page, password requirements are not visible.
2. When the user clicks on the password field, the password requirements pop up and are visible. The requirement text is in default gray/black.
3. The password requirements icons appear red until fulfilled, in which case they switch to green.
4. When a user begins typing in the “confirm password" field, a "confirm password" validation field stating "Passwords do not match" appears until the requirement is fulfilled. This field disappears when the password fields match.


https://github.com/user-attachments/assets/e58e90d8-2ed3-4f2b-a500-89cb9dfdc04a