### PR TITLE
Fix for "Reset Password" Functionality

### DIFF
--- a/client/src/services/authService.js
+++ b/client/src/services/authService.js
@@ -3,10 +3,12 @@ import sendRequest from './sendRequest';
 const BASE_URL = import.meta.env.VITE_SERVER_BASE_URL + 'api/users';
 
 export async function signUp(userData) {
+  console.log("Full request body:", userData);
   return await sendRequest(`${BASE_URL}/signup`, 'POST', userData);
 }
 
 export async function logIn(credentials) {
+  console.log("Full request body:", credentials);
   return await sendRequest(`${BASE_URL}/login`, 'POST', credentials);
 }
 
@@ -15,9 +17,30 @@ export async function logOut() {
 }
 
 export async function forgotPassword(data) {
+  console.log("Full request body:", data);
   return await sendRequest(`${BASE_URL}/forgot-password`, 'POST', data);
 }
 
 export async function resetPassword(data) {
-  return await sendRequest(`${BASE_URL}/reset-password/${data.token}`, 'POST', { password: data.newPassword });
+  console.log("Full request body:", { token: data.token, newPassword: data.newPassword });
+  return await sendRequest(`${BASE_URL}/reset-password/${data.token}`, 'POST', { newPassword: data.newPassword });
+}
+
+// In ResetPasswordPage.jsx
+async function handleSubmit(e) {
+  e.preventDefault();
+
+  if (!newPassword) {
+    setError("Password is required!");
+    return;
+  }
+
+  try {
+    await resetPassword({ token, newPassword });
+    setMessage('Password reset successfully!');
+    setError('');
+  } catch (err) {
+    setError(err.message || "An error occurred while resetting the password.");
+    setMessage('');
+  }
 }

--- a/server/controllers/api/userCtrl.js
+++ b/server/controllers/api/userCtrl.js
@@ -30,11 +30,8 @@ async function create(req, res) {
     const token = createJWT(user);
     res.cookie("token", token, cookieOptions);
     res.json(user);
-    console.log("User created:", user);
   } catch (error) {
     if (error.code === 11000) {
-      // MongoDB duplicate key error code
-      console.log(`We found a dup email or username Error: ${error}`);
       res
         .status(400)
         .json({
@@ -64,19 +61,10 @@ async function logIn(req, res) {
       throw new Error("Invalid credentials");
     }
 
-    console.log("User found:", {
-      id: user._id,
-      email: user.email,
-      username: user.username,
-      passwordHash: user.password.substring(0, 10) + "..." // Only log part of the hash for security
-    });
-
     const passwordMatch = await bcrypt.compare(
       req.body.password,
       user.password
     );
-
-    console.log("Password match result:", passwordMatch);
 
     if (!passwordMatch) {
       throw new Error("Invalid credentials");
@@ -84,10 +72,8 @@ async function logIn(req, res) {
 
     const token = createJWT(user);
     res.cookie("token", token, cookieOptions);
-    console.log("Login successful, token created");
     res.json(user);
   } catch (error) {
-    console.log("Login error:", error.message);
     res.status(400).json("Invalid credentials");
   }
 }
@@ -107,7 +93,6 @@ async function getUser(req, res) {
 }
 
 async function logOut(req, res) {
-  console.log("Entered the logout function.");
   try {
     res.cookie(
       "token",
@@ -158,7 +143,6 @@ async function forgotPassword(req, res) {
     res.status(200).json({ message: "Password resent link sent to your email account." });
   }
   catch (error) {
-    console.log(error.message)
     res.status(400).json({ message: error.message });
   }
 }
@@ -178,9 +162,6 @@ async function resetPassword(req, res) {
     if (!newPassword) {
       return res.status(400).json({ message: "New password is required" });
     }
-
-    console.log("Received reset request with token:", token);
-    console.log("Password data received:", newPassword ? "Password provided" : "No password provided");
 
     const resetPasswordData = await ResetUserPassword.findOne({ token });
 
@@ -202,7 +183,6 @@ async function resetPassword(req, res) {
 
     res.status(200).json({ message: "Password reset successfully" });
   } catch (error) {
-    console.error("Reset password error:", error);
     res.status(400).json({ message: error.message });
   }
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -19,6 +19,7 @@
         "mongodb": "^6.9.0",
         "mongoose": "^8.7.0",
         "morgan": "^1.10.0",
+        "resend": "^4.3.0",
         "serve-favicon": "^2.5.0"
       },
       "devDependencies": {
@@ -373,6 +374,52 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "node_modules/@react-email/render": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-1.0.6.tgz",
+      "integrity": "sha512-zNueW5Wn/4jNC1c5LFgXzbUdv5Lhms+FWjOvWAhal7gx5YVf0q6dPJ0dnR70+ifo59gcMLwCZEaTS9EEuUhKvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "html-to-text": "9.0.5",
+        "prettier": "3.5.3",
+        "react-promise-suspense": "0.3.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/render/node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -998,6 +1045,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -1050,6 +1106,61 @@
       "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dotenv": {
@@ -1106,6 +1217,18 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -1887,6 +2010,41 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -2191,6 +2349,15 @@
       "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/leac": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/levn": {
@@ -2843,6 +3010,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "license": "MIT",
+      "dependencies": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2881,6 +3061,15 @@
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
       "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
+    },
+    "node_modules/peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -3019,6 +3208,44 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/react": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-promise-suspense": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/react-promise-suspense/-/react-promise-suspense-0.3.4.tgz",
+      "integrity": "sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^2.0.1"
+      }
+    },
+    "node_modules/react-promise-suspense/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "license": "MIT"
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -3050,6 +3277,18 @@
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-4.3.0.tgz",
+      "integrity": "sha512-4OBHeusMVSl0vcba2J3AaGzdZ1SXAAhX/Wkcwobe16AHmlW9h3li8wG62Fhvlsc61e+wlQoxcwJZP6WrBTbghQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-email/render": "1.0.6"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/resolve-from": {
@@ -3112,6 +3351,25 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "license": "MIT",
+      "dependencies": {
+        "parseley": "^0.12.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/semver": {
       "version": "7.6.3",

--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
     "mongodb": "^6.9.0",
     "mongoose": "^8.7.0",
     "morgan": "^1.10.0",
+    "resend": "^4.3.0",
     "serve-favicon": "^2.5.0"
   },
   "scripts": {

--- a/server/utils/mail/customMail.js
+++ b/server/utils/mail/customMail.js
@@ -18,7 +18,7 @@ async function sendResetPasswordMail(to, resetUrl, username) {
          * @todo update mailoption
          */
         const mailOption = {
-            from: 'knownative@resend.dev', // sender address -- sample mail 'knownative@resend.dev'
+            from: 'onboarding@resend.dev', // sender address -- sample mail 'knownative@resend.dev'
             to: to, // list of receivers -- for test use your own email
             subject: "KnowNative - Reset Forgotten Password", // Subject line
             html: htmlContent


### PR DESCRIPTION
We identified and fixed an issue with the password reset flow where users were unable to log in with their newly reset passwords. The problem occurred because the password was being double-hashed during the reset process.

# Root Cause Analysis
1. When a user reset their password, we were:
- Manually hashing the new password with bcrypt
- Setting this hashed password on the user document
- Calling save() on the user document

2. The user model has a pre-save hook that automatically hashes passwords:
```
userSchema.pre('save', async function(next) {
  if (!this.isModified('password')) return next()
  this.password = await hash(this.password, SALT_ROUNDS)
  return next()
})
```

3. This resulted in the password being hashed twice:
- Once manually in the resetPassword function
- Again by the pre-save hook when saving the user document

4. When users tried to log in with their new password, the login function would hash the input once and compare it to the double-hashed stored password, resulting in a mismatch.

# Solution:

I modified the `resetPassword` function to bypass the pre-save hook by using Mongoose's `updateOne` method directly on the model instead of saving the document instance:

So, instead of:
```
userData.password = await bcrypt.hash(newPassword, 10);
await userData.save();
```

We are now using:
```
await User.updateOne(
  { _id: userData._id },
  { $set: { password: await bcrypt.hash(newPassword, 10) } }
)
```