### PR TITLE
Quick Fix for CORS origin address settings

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -17,7 +17,7 @@ app.use(express.json());
 //NOTE: CHANGE ORIGIN IF YOUR FRONTEND IS BEING SERVED ON A DIFFERENT
 app.use(
   cors({
-    origin: "http://localhost:5173",
+    origin: ["http://localhost:5173", "http://127.0.0.1:5173"],
     credentials: true,
   })
 );


### PR DESCRIPTION
### **Found a bug causing CORS verification errors when trying to log in or sign up.**

**Description of the problem:**
When the app is being accessed using the address `http://127.0.0.1:5173`, the server will _fail to fetch_ from the database due to a CORS origin mismatch.

Here's a screenshot of the error message:
![Failed to Fetch Error](https://github.com/user-attachments/assets/4e2e39ec-5694-494e-a522-371874e2f4d0)

The redirection from `http://localhost:5173` to `http://127.0.0.1:5173` is a normal behavior related to how Vite's server works and how Google Chrome browser handles these URLs, so it's not unusual to be redirected to either `localhost:5173` or `127.0.0.1:5173` when accessing the app.

When the redirection to `127.0.0.1:5173` happens, developers are bound to bump into a **_failed to fetch_** error message, resulting in the inability to create a user (sign up) or log in an existing user.

**Why this happens:**
1. **Hostname equivalence**: `localhost` and `127.0.0.1` are technically the same. Both refer to your local machine.
2. **Vite's server configuration:** By default, Vite binds to both localhost and 127.0.0.1. When you access the app by clicking on the blue link on VS Code, it might choose to redirect you to the IP address version.

**The Solution**
**CORS configuration update:** `server.js` needs CORS to allow both origins: `localhost:5173` and `127.0.0.1:5173`

```
app.use(
  cors({
    origin: ["http://localhost:5173", "http://127.0.0.1:5173"],
    credentials: true,
  })
);
```

This pull request updates the CORS configuration in the `server/server.js` file to allow requests from an additional origin.