### PR TITLE
fix: prevent flash of message on page refresh by adding loading spinner and states

### DIFF
--- a/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
+++ b/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
@@ -6,6 +6,7 @@ import Button from '../../ui-components/Button/button';
 import { getUserTexts } from '../../utilities/texts-api';
 import DashboardNavbar from '../components/DashboardNavbar';
 import AddTextSlideout from '../AddTextPage/AddTextSlideout';
+import Spinner from '../../ui-components/Spinner/spinner';
 
 const mockData = [
   {
@@ -287,7 +288,7 @@ const mockData = [
 ];
 
 export default function DashboardPage() {
-  const { user } = useAuthContext();
+  const { user, loading } = useAuthContext();
   const navigate = useNavigate();
   const [itemsToShow, setItemsToShow] = useState(3);
   const [fadeIn, setFadeIn] = useState(false);
@@ -404,7 +405,29 @@ export default function DashboardPage() {
     fetchTexts();
   }, [user]);
 
-  return user ? (
+  if (loading) {
+    return (
+      <div className="dashboard">
+        <div className="dashboard__main">
+          <div className="dashboard__loading-overlay">
+            <Spinner />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div>
+        <p>
+          User not logged in. Please log in <Link to="/login">here</Link>.
+        </p>
+      </div>
+    );
+  }
+
+  return (
     <div className="dashboard">
       <DashboardNavbar activeTab="Dashboard" />
       <div className="dashboard__main">
@@ -643,12 +666,6 @@ export default function DashboardPage() {
         className={`dashboard__overlay ${isAddTextOpen ? 'dashboard__overlay--active' : ''}`}
         onClick={() => setIsAddTextOpen(false)}></div>
       <AddTextSlideout isOpen={isAddTextOpen} onClose={() => setIsAddTextOpen(false)} />
-    </div>
-  ) : (
-    <div>
-      <p>
-        User not logged in. Please log in <Link to="/login">here</Link>.
-      </p>
     </div>
   );
 }

--- a/client/src/KnowNativePage/DashboardPage/DashboardPage.scss
+++ b/client/src/KnowNativePage/DashboardPage/DashboardPage.scss
@@ -264,6 +264,19 @@ $icon-colors: (
         }
     }
 
+    &__loading-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(0, 0, 0, 0.5);
+        z-index: 9999;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+
     @keyframes fadeIn {
         from {
             opacity: 0;

--- a/client/src/contexts/Auth/AuthProvider.jsx
+++ b/client/src/contexts/Auth/AuthProvider.jsx
@@ -13,6 +13,7 @@ function useAuthContext() {
 
 function AuthProvider({ children }) {
   const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     async function getUser() {
@@ -31,12 +32,14 @@ function AuthProvider({ children }) {
       } catch (err) {
         console.error(err.message);
         setUser(null);
+      } finally {
+        setLoading(false);
       }
     }
     getUser();
   }, []);
 
-  return <AuthContext.Provider value={{ user, setUser }}>{children}</AuthContext.Provider>;
+  return <AuthContext.Provider value={{ user, setUser, loading }}>{children}</AuthContext.Provider>;
 }
 
 export { AuthProvider, useAuthContext };


### PR DESCRIPTION
## ✅ Changes Made
- Added a loading state to the AuthProvider that is initially true and set to false after the user data is fetched (whether successful or not)
- Updated the DashboardPage to handle the loading state properly by:
  - First checking if we're loading
  - Then checking if there's no user
  - Finally rendering the dashboard if we have a user
This should prevent the "User not logged in" message from flashing during page refresh 

- Added `<spinner />` loader component to dashboard page  while checking `loading` state and added style  `&__loading-overlay` to DashboardPage.sass for spinner 

- optimised 'User not logged in ...' msg condition

---
Please tell me if anything need to change or does not work as expected.

## 🔗 Related Issue(s)
Fixes #267 


https://github.com/user-attachments/assets/093eab97-2282-4036-93eb-deb7ed461ac0

