### PR TITLE
Enable text viewing from dashboard

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -14,6 +14,7 @@ import DashboardPage from './KnowNativePage/DashboardPage/DashboardPage';
 import AppProvider from './contexts/AppProvider';
 import AddTextPage from './KnowNativePage/AddTextPage/AddTextPage';
 import CardsPage from './KnowNativePage/CardsPage/CardsPage';
+import TextsPage from './KnowNativePage/TextPage/TextsPage';
 
 function App() {
   return (
@@ -31,6 +32,7 @@ function App() {
           <Route path="/signup" element={<SignupPage />} />
           <Route path="/reset-password" element={<ResetPasswordPage />} />
           <Route path="/add-text" element={<AddTextPage />} />
+          <Route path="/text/:id?" element={<TextsPage />} />
           <Route path="/*" element={<LandingPage />} />
         </Routes>
       </main>

--- a/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
+++ b/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
@@ -607,7 +607,12 @@ export default function DashboardPage() {
                         <RoundIcon iconName="book_2" color="blue" />
                       </td>
                       <td>
-                        <div className="dashboard__table-container__name">{item.title}</div>
+                        <button
+                          className="dashboard__table-container__name dashboard__link"
+                          onClick={() => navigate(`/text/${item._id}`, { state: { text: item } })}
+                        >
+                          {item.title}
+                        </button>
                         <div className="dashboard__table-container__desc">{item.content}</div>
                       </td>
                       <td className={item.cards.length === 0 ? 'dashboard--text-red' : ''}>
@@ -620,8 +625,8 @@ export default function DashboardPage() {
                           iconStyling="reusable-button__icon-flip"
                           buttonVariant="tertiary"
                           buttonText="Review"
-                          buttonOnClickFunc={() => console.log('click click')}
-                          disabled={item.cards.length === 0 ? true : false}
+                          buttonOnClickFunc={() => navigate(`/text/${item._id}`, { state: { text: item } })}
+                          disabled={item.cards.length === 0}
                         />
                       </td>
                     </tr>

--- a/client/src/KnowNativePage/TextPage/TextsPage.jsx
+++ b/client/src/KnowNativePage/TextPage/TextsPage.jsx
@@ -1,0 +1,73 @@
+import React, { useState } from "react";
+import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
+import DashboardNavbar from "../components/DashboardNavbar";
+import "./TextsPage.scss";
+
+export default function TextsPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { id } = useParams(); 
+  const [activeTab, setActiveTab] = useState("read");
+  const [text, setText] = useState(location.state?.text || null);
+
+  function handleTabClick(tabName) {
+    setActiveTab(tabName);
+  }
+
+  if (!text) {
+    return (
+      <div style={{ padding: '2rem' }}>
+        <p>Text not found.</p>
+        <Link to="/dashboard">← Return to Dashboard</Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="dashboard">
+      <DashboardNavbar activeTab="Dashboard" />
+
+      <div className="dashboard__main">
+        <Link to="/dashboard" className="text-page__back">
+          <span className="material-symbols-outlined" style={{ fontSize: "32px", marginRight: "0.5rem" }}>
+            chevron_left
+          </span>
+          Return to Dashboard
+        </Link>
+
+     {/* Tabs for switching mode */}
+        <div className="tabs sticky-fade text-page__tabs-center">
+          <button className={`tabs__btn ${activeTab === "read" ? "tabs__btn--active" : ""}`} onClick={() => handleTabClick("read")}>Read</button>
+          <button className={`tabs__btn ${activeTab === "study" ? "tabs__btn--active" : ""}`} onClick={() => handleTabClick("study")}>Study</button>
+          <button className={`tabs__btn ${activeTab === "translate" ? "tabs__btn--active" : "" }`} onClick={() => handleTabClick("translate")}>Translate</button>
+        </div>
+
+        <div className="text-divider"></div>
+
+    {/*Render basecd on active tab */}
+        {activeTab === "read" && (
+            <section className="read-container read-container--active">
+                <div className="Text text-content">
+                    <h1 className="text-title">{text.title}</h1>
+                    <a
+                      href={text.source}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-source"
+                    >
+                      View Original Source
+                    </a>
+                    <div className="text-divider"></div>
+                    <p className="text-body">{text.content}</p>
+                </div>
+        </section>
+        )}
+
+        <div>
+          {activeTab === "study" && <p>This is the Study tab.</p>}
+          {activeTab === "translate" && <p>This is the Translate tab.</p>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/KnowNativePage/TextPage/TextsPage.scss
+++ b/client/src/KnowNativePage/TextPage/TextsPage.scss
@@ -1,0 +1,123 @@
+/*  Main layout styles */
+.text-page-container {
+    display: flex;
+  }
+  
+  .text-page {
+    margin-left: 285px; /* Width of the DashboardNavbar */
+    width: calc(100% - 285px);
+  }
+  
+  // Back button to Dashboard
+  .text-page__back {
+    display: inline-flex;
+    align-items: center;
+    margin: 2vmin 0;
+    color: #383E40;
+    text-decoration: none;
+    font-weight: 16px;
+  }
+  
+  .text-page__title {
+    font-size: 1.75rem;
+    margin-bottom: 0.5rem;
+  }
+  
+  .text-page__source {
+    display: block;
+    margin-bottom: 1.5rem;
+    font-size: 0.9rem;
+    color: #555;
+  }
+  
+  /* Tabs styles */
+  .tabs__btn {
+    font-family: 'Libre Franklin', sans-serif;
+    font-size: 24px;
+    font-weight: 400;
+    color: #383E40;
+    background: transparent;
+    border: none;
+    padding: 0.5rem 1.25rem;
+    cursor: pointer;
+    position: relative;
+  
+    &--active {
+      font-weight: 600;
+      color: #074B59;
+    }
+  
+    &::after {
+      content: "";
+      position: absolute;
+      bottom: 0px;
+      left: 0;
+      width: 100%;
+      height: 2px;
+      background-color: transparent;
+      transition: all 0.3s ease;
+    }
+  
+    &--active::after {
+      background-color: #2BA6A8;
+    }
+  }
+  
+  .text-page__tabs span:first-child {
+    border-bottom: 2px solid var(--teal);
+  }
+  
+  .text-page__tabs span {
+    font-weight: bold;
+    background-color: #eee;
+    padding: 0.5rem 1rem;
+    border-radius: 0.25rem;
+  }
+  
+  /* Read Tab Content Styles */
+  .text-page__content {
+    font-size: 1rem;
+    line-height: 1.6;
+    color: #333;
+    text-align: left;
+  }
+
+  .read-container {
+    display: flex;
+    justify-content: left;
+  }
+  
+  .Text {
+    width: 100%;
+    line-height: 2.95;
+    font-size: 1rem;
+    color: #222;
+  }
+  
+  .text-title {
+    font-size: 1.75rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    text-align: left;
+  }
+  
+  .text-source {
+    display: block;
+    margin-bottom: 1rem;
+    text-align: left; 
+    font-size: 0.9rem;
+    color: #282B2B;
+    text-decoration: underline;
+  }
+  
+  // Article content
+  .text-body {
+    white-space: pre-wrap;
+    text-align: left;
+  }
+  
+  .text-divider {
+    border-top: 1px solid #E1E3E3;
+    margin: 0.5rem 0 1.25rem;
+  }
+  


### PR DESCRIPTION
Fixes [#255](https://github.com/AbigailDawson/knownative/issues/255)

## Summary 
- Users can click a text from the dashboard to open it
- Displays the text's title, source link, and content
- Adds 3 static tabs at the top: Read, Study, Translate
- Includes "Return to Dashboard" link

![dashboard](https://github.com/user-attachments/assets/9d32e08d-e84b-45ec-8bf6-6e0777a658fc)
![readTab](https://github.com/user-attachments/assets/478f3d17-056a-4f65-847b-80672ccdd828)
