### PR TITLE
feat: added call back to update ui on successful post

### DIFF
--- a/client/src/KnowNativePage/AddTextPage/AddTextSlideout.jsx
+++ b/client/src/KnowNativePage/AddTextPage/AddTextSlideout.jsx
@@ -4,7 +4,7 @@ import sendRequest from '../../utilities/send-request';
 import { useAuthContext } from '../../contexts/Auth/AuthProvider';
 import './AddTextSlideout.scss';
 
-export default function AddTextSlideout({ isOpen, onClose }) {
+export default function AddTextSlideout({ isOpen, onClose, onSuccess }) {
   const [formData, setFormData] = useState({
     source: '',
     title: '',
@@ -61,6 +61,7 @@ export default function AddTextSlideout({ isOpen, onClose }) {
       try {
         const data = await sendRequest('/api/demo/texts', 'POST', formData);
         console.log('Text added:', data);
+        if (onSuccess) onSuccess();
         onClose(); // Close the slideout after successful submission
       } catch (error) {
         console.error('Oops! Error submitting form:', error);

--- a/client/src/KnowNativePage/AddTextPage/AddTextSlideout.jsx
+++ b/client/src/KnowNativePage/AddTextPage/AddTextSlideout.jsx
@@ -61,7 +61,7 @@ export default function AddTextSlideout({ isOpen, onClose, onSuccess }) {
       try {
         const data = await sendRequest('/api/demo/texts', 'POST', formData);
         console.log('Text added:', data);
-        if (onSuccess) onSuccess();
+        if (onSuccess) onSuccess(); // Callback to notify parent component of success
         onClose(); // Close the slideout after successful submission
       } catch (error) {
         console.error('Oops! Error submitting form:', error);

--- a/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
+++ b/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
@@ -391,17 +391,18 @@ export default function DashboardPage() {
     );
   };
 
-  useEffect(() => {
-    const fetchTexts = async () => {
-      try {
-        if (user._id) {
-          const texts = await getUserTexts();
-          setTexts(texts);
-        }
-      } catch (error) {
-        console.log('Error fetching texts:', error);
+  const fetchTexts = async () => {
+    try {
+      if (user._id) {
+        const texts = await getUserTexts();
+        setTexts(texts);
       }
-    };
+    } catch (error) {
+      console.log('Error fetching texts:', error);
+    }
+  };
+
+  useEffect(() => {
     fetchTexts();
   }, [user]);
 
@@ -609,8 +610,7 @@ export default function DashboardPage() {
                       <td>
                         <button
                           className="dashboard__table-container__name dashboard__link"
-                          onClick={() => navigate(`/text/${item._id}`, { state: { text: item } })}
-                        >
+                          onClick={() => navigate(`/text/${item._id}`, { state: { text: item } })}>
                           {item.title}
                         </button>
                         <div className="dashboard__table-container__desc">{item.content}</div>
@@ -625,7 +625,9 @@ export default function DashboardPage() {
                           iconStyling="reusable-button__icon-flip"
                           buttonVariant="tertiary"
                           buttonText="Review"
-                          buttonOnClickFunc={() => navigate(`/text/${item._id}`, { state: { text: item } })}
+                          buttonOnClickFunc={() =>
+                            navigate(`/text/${item._id}`, { state: { text: item } })
+                          }
                           disabled={item.cards.length === 0}
                         />
                       </td>
@@ -670,7 +672,11 @@ export default function DashboardPage() {
       <div
         className={`dashboard__overlay ${isAddTextOpen ? 'dashboard__overlay--active' : ''}`}
         onClick={() => setIsAddTextOpen(false)}></div>
-      <AddTextSlideout isOpen={isAddTextOpen} onClose={() => setIsAddTextOpen(false)} />
+      <AddTextSlideout
+        isOpen={isAddTextOpen}
+        onClose={() => setIsAddTextOpen(false)}
+        onSuccess={fetchTexts}
+      />
     </div>
   );
 }

--- a/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
+++ b/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
@@ -7,6 +7,7 @@ import { getUserTexts } from '../../utilities/texts-api';
 import DashboardNavbar from '../components/DashboardNavbar';
 import AddTextSlideout from '../AddTextPage/AddTextSlideout';
 import Spinner from '../../ui-components/Spinner/spinner';
+import { fetchTexts } from '../../utilities/texts-api';
 
 const mockData = [
   {
@@ -389,17 +390,6 @@ export default function DashboardPage() {
         )}
       </div>
     );
-  };
-
-  const fetchTexts = async () => {
-    try {
-      if (user._id) {
-        const texts = await getUserTexts();
-        setTexts(texts);
-      }
-    } catch (error) {
-      console.log('Error fetching texts:', error);
-    }
   };
 
   useEffect(() => {

--- a/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
+++ b/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
@@ -393,7 +393,7 @@ export default function DashboardPage() {
   };
 
   useEffect(() => {
-    fetchTexts();
+    fetchTexts(user, setTexts);
   }, [user]);
 
   if (loading) {
@@ -665,7 +665,7 @@ export default function DashboardPage() {
       <AddTextSlideout
         isOpen={isAddTextOpen}
         onClose={() => setIsAddTextOpen(false)}
-        onSuccess={fetchTexts}
+        onSuccess={() => fetchTexts(user, setTexts)}
       />
     </div>
   );

--- a/client/src/utilities/texts-api.js
+++ b/client/src/utilities/texts-api.js
@@ -1,46 +1,57 @@
-import sendRequest from './send-request'
-const BASE_URL = '/api/texts'
+import sendRequest from './send-request';
+const BASE_URL = '/api/texts';
 
 export async function tokenizeText(text) {
-  return sendRequest(`${BASE_URL}/tokenize`, 'POST', { text })
+  return sendRequest(`${BASE_URL}/tokenize`, 'POST', { text });
 }
 
 export function getAll() {
-  return sendRequest(`${BASE_URL}`)
+  return sendRequest(`${BASE_URL}`);
 }
 
 export function addNewText(textData) {
-  return sendRequest(`${BASE_URL}/add`, 'POST', textData)
+  return sendRequest(`${BASE_URL}/add`, 'POST', textData);
 }
 
 export function deleteText(text, id) {
-  return sendRequest(`${BASE_URL}/${id}/delete`, 'DELETE', { text })
+  return sendRequest(`${BASE_URL}/${id}/delete`, 'DELETE', { text });
 }
 
 export function getText(id) {
-  return sendRequest(`${BASE_URL}/${id}`)
+  return sendRequest(`${BASE_URL}/${id}`);
 }
 
 export function saveWord(word, textId) {
-  return sendRequest(`${BASE_URL}/${textId}/save`, 'POST', { word })
+  return sendRequest(`${BASE_URL}/${textId}/save`, 'POST', { word });
 }
 
 export function getSavedWords(textId) {
-  return sendRequest(`${BASE_URL}/${textId}/get-saved-words`)
+  return sendRequest(`${BASE_URL}/${textId}/get-saved-words`);
 }
 
 export function translateSentence(sentence) {
-  return sendRequest(`${BASE_URL}/translate`, 'POST', { sentence })
+  return sendRequest(`${BASE_URL}/translate`, 'POST', { sentence });
 }
 
 export function archiveText(text, id) {
-  return sendRequest(`${BASE_URL}/${id}/archive`, 'POST', { text })
+  return sendRequest(`${BASE_URL}/${id}/archive`, 'POST', { text });
 }
 
 export function favoriteText(text, id) {
-  return sendRequest(`${BASE_URL}/${id}/favorite`, 'POST', { text })
+  return sendRequest(`${BASE_URL}/${id}/favorite`, 'POST', { text });
 }
 
 export const getUserTexts = async () => {
   return sendRequest(`${BASE_URL}/getTexts`, 'GET');
+};
+
+export const fetchTexts = async () => {
+  try {
+    if (user._id) {
+      const texts = await getUserTexts();
+      setTexts(texts);
+    }
+  } catch (error) {
+    console.log('Error fetching texts:', error);
+  }
 };

--- a/client/src/utilities/texts-api.js
+++ b/client/src/utilities/texts-api.js
@@ -45,7 +45,7 @@ export const getUserTexts = async () => {
   return sendRequest(`${BASE_URL}/getTexts`, 'GET');
 };
 
-export const fetchTexts = async () => {
+export const fetchTexts = async (user, setTexts) => {
   try {
     if (user._id) {
       const texts = await getUserTexts();


### PR DESCRIPTION
Bug Summary:
When a user adds a new text via the form:

The form successfully submits (POST request works)

The new text does not immediately appear in the library UI

A manual page refresh is required to see the new text

Root Cause:
The useEffect in our Dashboard component fetches texts only on mount (initial render), due to [user] dependency.

After the POST request in <AddTextSlideout />, nothing triggers a re-fetch of the updated text list.

Solution:
Create a callback function in Dashboard to re-fetch texts

Pass this callback to <AddTextSlideout /> component

Call it inside the handleSubmit after a successful post
```jsx

//Dashboard.jsx
//moved to be a global function that wont change on rendering
const fetchTexts = async () => {
    try {
      if (user._id) {
        const texts = await getUserTexts();
        setTexts(texts);
      }
    } catch (error) {
      console.log('Error fetching texts:', error);
    }
  };

//added callback prop onSuccess
<AddTextSlideout
        isOpen={isAddTextOpen}
        onClose={() => setIsAddTextOpen(false)}
        onSuccess={fetchTexts}
      />

//AddTextSlideOut.jsx
// Callback to notify parent component of success
 const handleSubmit = async (e) => {
    e.preventDefault();
    if (validateForm()) {
      try {
        const data = await sendRequest('/api/demo/texts', 'POST', formData);
        console.log('Text added:', data);
        if (onSuccess) onSuccess();
        onClose(); // Close the slideout after successful submission
      } catch (error) {
        console.error('Oops! Error submitting form:', error);
      }
    }
  };
```
