### PR TITLE
Add word click popup feature on Study tab

### DIFF
--- a/client/src/KnowNativePage/TextPage/StudyTab.jsx
+++ b/client/src/KnowNativePage/TextPage/StudyTab.jsx
@@ -2,15 +2,15 @@ import { useEffect, useState } from "react";
 import * as demoAPI from "../../utilities/demo-api"
 import "./StudyTab.scss";
 
-/**
- * StudyTab
- * Shows the current text, split into word objects using the demo tokenizer
- * – There aren't any click handlers yet
- */
+import WordPopup from "./components/WordPopup/WordPopup";
+import { getWordInfo } from "../../utilities/words-service";
 
 export default function StudyTab({ text }) {
   const [tokens, setTokens] = useState([]);
+  const [activeWord, setActiveWord] = useState(null);
 
+
+  // call demo API; replace with real API call later
   useEffect(() => {
     async function fetchTokens() {
       if (!text?.content) return;
@@ -31,11 +31,38 @@ export default function StudyTab({ text }) {
     <section className="study">
       <div className="study__body">
         {tokens.map((w, i) => (
-          <span key={i} className="study__word">
+          <span
+            key={i}
+            className={
+              "study__word" + 
+              (activeWord?.index === i ? " study__word--active" : "")
+            }
+
+            // when clicked pull pronunciation + meaning from word data and open popup
+            onClick={(e) => {
+              const { pinyin = "", meaning = "", charGroup } = getWordInfo(w);
+              setActiveWord({
+                index: i,
+                chars: charGroup || w.text,
+                pinyin,
+                meaning,
+                rect: e.target.getBoundingClientRect(), // store click position for popup placement
+              });
+            }}
+          >
             {w.text}
           </span>
         ))}
       </div>
+
+      {/* show popup if a word was clicked */}
+      {activeWord && (
+        <WordPopup
+          word={activeWord}
+          anchorRect={activeWord.rect}
+          onClose={() => setActiveWord(null)}
+        />
+      )}
     </section>
   );
 }

--- a/client/src/KnowNativePage/TextPage/StudyTab.jsx
+++ b/client/src/KnowNativePage/TextPage/StudyTab.jsx
@@ -34,8 +34,7 @@ export default function StudyTab({ text }) {
           <span
             key={i}
             className={
-              "study__word" + 
-              (activeWord?.index === i ? " study__word--active" : "")
+              "study__word"
             }
 
             // when clicked pull pronunciation + meaning from word data and open popup

--- a/client/src/KnowNativePage/TextPage/StudyTab.scss
+++ b/client/src/KnowNativePage/TextPage/StudyTab.scss
@@ -16,6 +16,6 @@
   display: inline-block;
 }
 
-.study__word--active {
-  background: #EFFFFC;
+.study__word:hover:not(.study__word--active) {
+  background: #ddfcf6;
 }

--- a/client/src/KnowNativePage/TextPage/StudyTab.scss
+++ b/client/src/KnowNativePage/TextPage/StudyTab.scss
@@ -12,5 +12,10 @@
 }
 
 .study__word {
+  cursor: pointer;
   display: inline-block;
+}
+
+.study__word--active {
+  background: #EFFFFC;
 }

--- a/client/src/KnowNativePage/TextPage/components/WordPopup/WordPopup.jsx
+++ b/client/src/KnowNativePage/TextPage/components/WordPopup/WordPopup.jsx
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from "react";
+import "./WordPopup.scss";
+
+export default function WordPopup({ word, anchorRect, onClose }) {
+  const ref = useRef(null);
+
+  // close popup if clicked outside of it
+  useEffect(() => {
+    const handle = (e) => !ref.current?.contains(e.target) && onClose();
+    document.addEventListener("mousedown", handle);
+    return () => document.removeEventListener("mousedown", handle);
+  }, [onClose]);
+
+  // position popup above the clicked word
+  const style = anchorRect
+    ? { top: anchorRect.top - 160, left: anchorRect.left }
+    : {};
+
+  return (
+    <div ref={ref} className="word-popup" style={style}>
+      <button className="word-popup__close" onClick={onClose}>✕</button>
+      <p className="word-popup__pinyin">{word.pinyin}</p>
+      <p className="word-popup__chars">{word.chars}</p>
+      <p className="word-popup__meaning">{word.meaning}</p>
+      <button className="word-popup__add">＋</button>
+    </div>
+  );
+}

--- a/client/src/KnowNativePage/TextPage/components/WordPopup/WordPopup.jsx
+++ b/client/src/KnowNativePage/TextPage/components/WordPopup/WordPopup.jsx
@@ -13,7 +13,10 @@ export default function WordPopup({ word, anchorRect, onClose }) {
 
   // position popup above the clicked word
   const style = anchorRect
-    ? { top: anchorRect.top - 160, left: anchorRect.left }
+    ? {
+        top: anchorRect.top - 160,
+        left: anchorRect.left + anchorRect.width / 2 - 100
+    }
     : {};
 
   return (

--- a/client/src/KnowNativePage/TextPage/components/WordPopup/WordPopup.scss
+++ b/client/src/KnowNativePage/TextPage/components/WordPopup/WordPopup.scss
@@ -1,0 +1,69 @@
+.word-popup {
+  position: absolute;
+  padding: .75rem;
+  border: 1px solid #57bcaa;
+  background: #EFFFFC;
+  border-radius: .5rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, .15);
+  z-index: 1000;
+  text-align: left;
+  width: 200px;
+  max-width: 350px; //expands when needed
+  min-height: 150px;
+
+  &__close {
+    position: absolute;
+    top: .25rem;
+    right: .25rem;
+    border: none;
+    background: none;
+    font-size: 1rem;
+    color: #7ea5a4;
+    cursor: pointer;
+  }
+
+  &__add {
+    position: absolute;
+    bottom: .5rem;
+    right: .5rem;
+    width: 2rem;
+    height: 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    border-radius: 50%;
+    background: #57bcaa;
+    color: #ffffff;
+    font-size: 1.25rem;
+    cursor: pointer;
+  }
+
+  &__chars {
+    font-size: 1.6rem;
+    font-weight: 700;
+    margin: .25rem 0;
+  }
+
+  &__pinyin {
+    color: #555555;
+    margin: 0;
+  }
+
+  &__meaning {
+    margin: .25rem 0 0;
+  }
+}
+
+.word-popup::after {
+  content: ""; // creates the little triangle box shape
+  position: absolute;
+  bottom: -6px;
+  left: 40px;
+  width: 10px;
+  height: 10px;
+  background: #EFFFFC;
+  border-bottom: 1px solid #57bcaa;
+  border-right: 1px solid #57bcaa;
+  transform: rotate(45deg);
+}

--- a/client/src/KnowNativePage/TextPage/components/WordPopup/WordPopup.scss
+++ b/client/src/KnowNativePage/TextPage/components/WordPopup/WordPopup.scss
@@ -1,7 +1,7 @@
 .word-popup {
   position: absolute;
   padding: .75rem;
-  border: 1px solid #57bcaa;
+  border: 1px solid #bed3d1;
   background: #EFFFFC;
   border-radius: .5rem;
   box-shadow: 0 2px 6px rgba(0, 0, 0, .15);
@@ -63,7 +63,7 @@
   width: 10px;
   height: 10px;
   background: #EFFFFC;
-  border-bottom: 1px solid #57bcaa;
-  border-right: 1px solid #57bcaa;
+  border-bottom: 1px solid #bed3d1;
+  border-right: 1px solid #bed3d1;
   transform: translateX(-50%) rotate(45deg);
 }

--- a/client/src/KnowNativePage/TextPage/components/WordPopup/WordPopup.scss
+++ b/client/src/KnowNativePage/TextPage/components/WordPopup/WordPopup.scss
@@ -59,11 +59,11 @@
   content: ""; // creates the little triangle box shape
   position: absolute;
   bottom: -6px;
-  left: 40px;
+  left: 50%;
   width: 10px;
   height: 10px;
   background: #EFFFFC;
   border-bottom: 1px solid #57bcaa;
   border-right: 1px solid #57bcaa;
-  transform: rotate(45deg);
+  transform: translateX(-50%) rotate(45deg);
 }


### PR DESCRIPTION
Fixes #257

## Summary
- User can click on any word to show the popup
- Popup positioned relative to the clicked word so the clicked word is still visible
- Information from the dictionary to display the characters, meaning and pronunciation on the popup
- Popup contain an "X" to close the popup when clicked
- User can also close the popup by clicking anywhere outside the popup
- Popup contains an "+" circle button (not clickable yet) 

Side note,  in some cases the dictionary may return alternate definitions (such as place names). This reflects the current data available and is expected behavior for now.

![screenshot1](https://github.com/user-attachments/assets/fb872555-98fd-4bc6-8642-d72332b84c1d)
![screenshot2](https://github.com/user-attachments/assets/d25d0f48-eadd-4cab-a63d-3d151d1f6fb2)
![screenshot3](https://github.com/user-attachments/assets/772afea8-8797-4f2c-b93d-f217d1248881)
![screenshot4](https://github.com/user-attachments/assets/70903c30-cb80-4226-8f5b-6c572e230252)