### PR TITLE
Saving Functionality for Words in Study Tab

### DIFF
--- a/client/src/KnowNativePage/TextPage/StudyTab.jsx
+++ b/client/src/KnowNativePage/TextPage/StudyTab.jsx
@@ -45,6 +45,7 @@ export default function StudyTab({ text }) {
                 chars: charGroup || w.text,
                 pinyin,
                 meaning,
+                textId: text._id,
                 rect: e.target.getBoundingClientRect(), // store click position for popup placement
               });
             }}

--- a/client/src/KnowNativePage/TextPage/components/WordPopup/WordPopup.jsx
+++ b/client/src/KnowNativePage/TextPage/components/WordPopup/WordPopup.jsx
@@ -44,7 +44,7 @@ export default function WordPopup({ word, anchorRect, onClose }) {
       <p className="word-popup__chars">{word.chars}</p>
       <p className="word-popup__meaning">{word.meaning}</p>
       <button 
-        className={`word-popup__add${saved ? " saved" : ""}`}
+        className={`word-popup__add${saved ? " word-popup__add--saved" : ""}`}
         onClick={handleSave}
       >
         {saved ? "✓" : "＋"}

--- a/client/src/KnowNativePage/TextPage/components/WordPopup/WordPopup.jsx
+++ b/client/src/KnowNativePage/TextPage/components/WordPopup/WordPopup.jsx
@@ -1,8 +1,10 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import { saveWord } from "../../../../utilities/words-api";
 import "./WordPopup.scss";
 
 export default function WordPopup({ word, anchorRect, onClose }) {
   const ref = useRef(null);
+  const [saved, setSaved] = useState(false);
 
   // close popup if clicked outside of it
   useEffect(() => {
@@ -19,13 +21,34 @@ export default function WordPopup({ word, anchorRect, onClose }) {
     }
     : {};
 
+  async function handleSave() {
+    if (saved) return;
+    try {
+      await saveWord({
+        textId: word.textId,
+        traditional: word.chars,
+        pinyin: word.pinyin,
+        meaning: word.meaning,
+      });
+      setSaved(true);
+    } catch (err) {
+      if (err?.status === 409) setSaved(true);
+      console.error(err);
+    }
+  }
+
   return (
     <div ref={ref} className="word-popup" style={style}>
       <button className="word-popup__close" onClick={onClose}>✕</button>
       <p className="word-popup__pinyin">{word.pinyin}</p>
       <p className="word-popup__chars">{word.chars}</p>
       <p className="word-popup__meaning">{word.meaning}</p>
-      <button className="word-popup__add">＋</button>
+      <button 
+        className={`word-popup__add${saved ? " saved" : ""}`}
+        onClick={handleSave}
+      >
+        {saved ? "✓" : "＋"}
+      </button>
     </div>
   );
 }

--- a/client/src/KnowNativePage/TextPage/components/WordPopup/WordPopup.scss
+++ b/client/src/KnowNativePage/TextPage/components/WordPopup/WordPopup.scss
@@ -69,7 +69,7 @@
 }
 
 //hide circle when word is saved
-.word-popup__add.saved {
+.word-popup__add--saved {
   background: transparent;
   color: #57bcaa
 }

--- a/client/src/KnowNativePage/TextPage/components/WordPopup/WordPopup.scss
+++ b/client/src/KnowNativePage/TextPage/components/WordPopup/WordPopup.scss
@@ -67,3 +67,9 @@
   border-right: 1px solid #bed3d1;
   transform: translateX(-50%) rotate(45deg);
 }
+
+//hide circle when word is saved
+.word-popup__add.saved {
+  background: transparent;
+  color: #57bcaa
+}

--- a/client/src/utilities/send-request.js
+++ b/client/src/utilities/send-request.js
@@ -7,6 +7,12 @@ export default async function sendRequest(url, method = 'GET', payload = null) {
   }
 
   const res = await fetch(url, options)
-  if (res.ok) return res.json()
-  throw new Error('Bad Request')
+
+    if (res.ok) {
+    return res.status === 204 ? null : res.json();
+  }
+  
+  const err = new Error('Request failed');
+  err.status = res.status;
+  throw err;
 }

--- a/client/src/utilities/words-api.js
+++ b/client/src/utilities/words-api.js
@@ -10,5 +10,9 @@ export function deleteWord(word) {
 }
 
 export function countSavedWords() {
-  return sendRequest(`${BASE_URL}/count`)
+  return sendRequest(`${BASE_URL}/count`);
+}
+
+export function saveWord(data) {
+  return sendRequest('/api/texts/saveWord', 'POST', data);
 }

--- a/server/controllers/api/textController.js
+++ b/server/controllers/api/textController.js
@@ -40,7 +40,41 @@ const getUserTexts = async (req, res) => {
     }
   };
 
+  // Save a word to a user's text (POST /api/texts/saveWord)
+async function saveWord(req, res) {
+  try {
+    const { textId, traditional, pinyin, meaning } = req.body;
+    const userId = req.user._id;
+
+    if (!textId || !traditional) {
+      return res.status(400).json({ message: "textId and traditional are required" });
+    }
+
+    // stop duplicates for the same user + text + characters
+    const exists = await Card.findOne({
+      user: userId,
+      text: textId,
+      "frontProperties.traditional": traditional,
+    });
+    if (exists) return res.status(409).json({ message: "Word already saved" });
+
+    const card = await Card.create({
+      user: userId,
+      text: textId,
+      frontProperties: { traditional, easier: traditional, pinyin },
+      backProperties: { meaning },
+    });
+
+    await Text.findByIdAndUpdate(textId, { $push: { cards: card._id } });
+    res.status(201).json(card);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "Server error" });
+  }
+}
+
   module.exports = {
     getUserTexts,
-    deleteUserText
+    deleteUserText,
+    saveWord,
 };

--- a/server/controllers/api/textController.js
+++ b/server/controllers/api/textController.js
@@ -65,7 +65,10 @@ async function saveWord(req, res) {
       backProperties: { meaning },
     });
 
-    await Text.findByIdAndUpdate(textId, { $push: { cards: card._id } });
+    // Mongoose style load text add card and save
+    const text = await Text.findById(textId);
+    text.cards.push(card._id);
+    await text.save();
     res.status(201).json(card);
   } catch (err) {
     console.error(err);

--- a/server/routes/api/textRoutes.js
+++ b/server/routes/api/textRoutes.js
@@ -1,9 +1,10 @@
 const express = require("express");
-const { getUserTexts, deleteUserText } = require("../../controllers/api/textController");
+const { getUserTexts, deleteUserText, saveWord } = require("../../controllers/api/textController");
 const router = express.Router();
 const { verifyJWT } = require("./../../utils/jwt");
 
 router.get("/getTexts", verifyJWT, getUserTexts);
 router.delete("/:userId/text/:textId", deleteUserText);
+router.post("/saveWord", verifyJWT, saveWord);
 
 module.exports = router;


### PR DESCRIPTION
Fixes Sub-issue #273 

## Summary
**Frontend**
- Users can click add "+" button on word popup in Study tab
- Connect button to save-word API endpoint
- Show "✓" checkmark when word is successfully saved

**Backend**
- Create endpoint to save a word to the user's account
- Return 409 to handle error cases (duplicate words)

![1](https://github.com/user-attachments/assets/0ff9f717-ab1e-427b-83ff-87582394cac4)
![2](https://github.com/user-attachments/assets/4a5430b7-7858-4348-bd26-da3252433130)
![3](https://github.com/user-attachments/assets/5abed03f-ce75-4dea-a30f-5f49a049ac74)

