### PR TITLE
Sass Deprecation Warnings Cleanup

### DIFF
--- a/client/src/DemoPage/DemoMainContent/DemoStudyText/components/DemoWord/DemoWord.scss
+++ b/client/src/DemoPage/DemoMainContent/DemoStudyText/components/DemoWord/DemoWord.scss
@@ -20,6 +20,9 @@
   align-items: center;
   justify-content: center;
   font-family: 'Montserrat', 'Roboto', sans-serif;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   
   & p {
     margin: 0;
@@ -27,9 +30,6 @@
 
   &__zh {
     margin: 0;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
 
     &:hover {
       background-color: #d5fbf4;

--- a/client/src/DemoPage/DemoMainContent/DemoStudyText/components/DemoWord/DemoWord.scss
+++ b/client/src/DemoPage/DemoMainContent/DemoStudyText/components/DemoWord/DemoWord.scss
@@ -27,6 +27,9 @@
 
   &__zh {
     margin: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 
     &:hover {
       background-color: #d5fbf4;
@@ -67,13 +70,6 @@
     text-underline-offset: 4px;
     text-decoration-thickness: 1.5px;
   }
-
-  /* Prevent long words from wrapping and handle overflow text */
-  white-space: nowrap;
-  /*Handle overflow text*/
-  overflow: hidden;
-  /*Adds an ellipsis to indicate that the text is truncated*/
-  text-overflow: ellipsis;
 }
 
 /* Media Queries */


### PR DESCRIPTION
This is a minor update that addresses a Sass feature deprecation warning we were getting when initializing React.

The fix updates the styling for the `DemoWord` component. The properties that prevent text wrapping and add ellipsis for overflow have been moved from the bottom section of the `study-word`, `.specialChar` selector back to the top of `.DemoWord` class for proper application.

* Moved `white-space: nowrap`, `overflow: hidden`, and `text-overflow: ellipsis` from the inner selector to the main `.study-word, .specialChar` class in `DemoWord.scss`, ensuring long words are truncated with an ellipsis and do not wrap.

Closes #296 