### PR TITLE
Fix the client `deleteText()` function to point to the correct server endpoint.

### DIFF
--- a/client/src/utilities/texts-api.js
+++ b/client/src/utilities/texts-api.js
@@ -13,8 +13,8 @@ export function addNewText(textData) {
   return sendRequest(`${BASE_URL}/add`, 'POST', textData);
 }
 
-export function deleteText(text, id) {
-  return sendRequest(`${BASE_URL}/${id}/delete`, 'DELETE', { text });
+export function deleteText(textId, userId) {
+  return sendRequest(`/api/texts/${userId}/text/${textId}`, 'DELETE');
 }
 
 export function getText(id) {

--- a/client/src/utilities/texts-api.js
+++ b/client/src/utilities/texts-api.js
@@ -14,7 +14,7 @@ export function addNewText(textData) {
 }
 
 export function deleteText(textId, userId) {
-  return sendRequest(`/api/texts/${userId}/text/${textId}`, 'DELETE');
+  return sendRequest(`${BASE_URL}/${userId}/text/${textId}`, 'DELETE');
 }
 
 export function getText(id) {


### PR DESCRIPTION
Closes #304 

This pull request updates the `deleteText` function in `client/src/utilities/texts-api.js` to connect to the correct server API enpoint.

### Changes made:

* The `deleteText` function now takes `textId` and `userId` as parameters instead of `text` and `id`, and calls the API endpoint `/api/texts/${userId}/text/${textId}` with a `DELETE` request, removing the request body.