### PR TITLE
Launch the Flashcard Game Modal Overlay

### DIFF
--- a/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
+++ b/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
@@ -142,7 +142,7 @@ export default function DashboardPage() {
     );
   };
 
-  function startQuiz() {
+  function startFlashcardActivity() {
     setIsQuizModalOpen(true);
   }
 
@@ -303,7 +303,7 @@ export default function DashboardPage() {
                     iconStyling="reusable-button__icon-flip"
                     buttonVariant="tertiary"
                     buttonText="Review"
-                    buttonOnClickFunc={startQuiz}
+                    buttonOnClickFunc={startFlashcardActivity}
                   />
                 )}
             </div>
@@ -408,7 +408,7 @@ export default function DashboardPage() {
                             iconStyling="reusable-button__icon-flip"
                             buttonVariant="tertiary"
                             buttonText="Review"
-                            buttonOnClickFunc={startQuiz}
+                            buttonOnClickFunc={startFlashcardActivity}
                           />
                         )}
                         <button

--- a/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
+++ b/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
@@ -11,285 +11,7 @@ import Modal from '../../ui-components/Modal/modal';
 import { fetchTexts, deleteText } from '../../utilities/texts-api';
 import { getAllCards } from '../../utilities/cards-api'
 import { useSavedWordsDispatch, useSavedWordsContext }  from '../../contexts/SavedWords/SavedWordsProvider';
-
-const mockData = [
-  {
-    _id: 1,
-    title: '駕駛執照',
-    content:
-      '每天我要到許多地方去，也會遇到很多人。有些人喜歡叫我「左轉」、「右轉」、「停」；有些人會把髒東西留在我的車上。不過也有一些不錯的人，可以從他們身上學到很多東西，所以我也交了好幾個朋友。真是什麼樣的人都有啊！',
-    cards: [
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      },
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      },
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      },
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      },
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      },
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      }
-    ],
-    lastOpened: 'Oct 29, 2024'
-  },
-  {
-    _id: 2,
-    title: '銷售促進',
-    content:
-      '每天我要到許多地方去，也會遇到很多人。有些人喜歡叫我「左轉」、「右轉」、「停」；有些人會把髒東西留在我的車上。不過也有一些不錯的人，可以從他們身上學到很多東西，所以我也交了好幾個朋友。真是什麼樣的人都有啊！',
-    cards: [
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      },
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      },
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      }
-    ],
-    lastOpened: 'Oct 25, 2024'
-  },
-  {
-    _id: 3,
-    title: '開計程車',
-    content:
-      '每天我要到許多地方去，也會遇到很多人。有些人喜歡叫我「左轉」、「右轉」、「停」；有些人會把髒東西留在我的車上。不過也有一些不錯的人，可以從他們身上學到很多東西，所以我也交了好幾個朋友。真是什麼樣的人都有啊！',
-    cards: [],
-    lastOpened: 'Feb 25, 2025'
-  },
-  {
-    _id: 4,
-    title: '開計程車',
-    content:
-      '每天我要到許多地方去，也會遇到很多人。有些人喜歡叫我「左轉」、「右轉」、「停」；有些人會把髒東西留在我的車上。不過也有一些不錯的人，可以從他們身上學到很多東西，所以我也交了好幾個朋友。真是什麼樣的人都有啊！',
-    cards: [
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      },
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      }
-    ],
-    lastOpened: 'Feb 25, 2025'
-  },
-  {
-    _id: 5,
-    title: '開計程車',
-    content:
-      '每天我要到許多地方去，也會遇到很多人。有些人喜歡叫我「左轉」、「右轉」、「停」；有些人會把髒東西留在我的車上。不過也有一些不錯的人，可以從他們身上學到很多東西，所以我也交了好幾個朋友。真是什麼樣的人都有啊！',
-    cards: [
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      }
-    ],
-    lastOpened: 'Feb 25, 2025'
-  },
-  {
-    _id: 6,
-    title: '開計程車',
-    content:
-      '每天我要到許多地方去，也會遇到很多人。有些人喜歡叫我「左轉」、「右轉」、「停」；有些人會把髒東西留在我的車上。不過也有一些不錯的人，可以從他們身上學到很多東西，所以我也交了好幾個朋友。真是什麼樣的人都有啊！',
-    cards: [
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      },
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      },
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      },
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      },
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      },
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      }
-    ],
-    lastOpened: 'Feb 25, 2025'
-  },
-  {
-    _id: 7,
-    title: '快遞服務',
-    content:
-      '每天我要到許多地方去，也會遇到很多人。有些人喜歡叫我「左轉」、「右轉」、「停」；有些人會把髒東西留在我的車上。不過也有一些不錯的人，可以從他們身上學到很多東西，所以我也交了好幾個朋友。真是什麼樣的人都有啊！',
-    cards: [],
-    lastOpened: 'Feb 25, 2025'
-  },
-  {
-    _id: 8,
-    title: '開計程車',
-    content:
-      '每天我要到許多地方去，也會遇到很多人。有些人喜歡叫我「左轉」、「右轉」、「停」；有些人會把髒東西留在我的車上。不過也有一些不錯的人，可以從他們身上學到很多東西，所以我也交了好幾個朋友。真是什麼樣的人都有啊！',
-    cards: [
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      },
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      },
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      }
-    ],
-    lastOpened: 'Feb 25, 2025'
-  },
-  {
-    _id: 9,
-    title: '乘車券',
-    content:
-      '每天我要到許多地方去，也會遇到很多人。有些人喜歡叫我「左轉」、「右轉」、「停」；有些人會把髒東西留在我的車上。不過也有一些不錯的人，可以從他們身上學到很多東西，所以我也交了好幾個朋友。真是什麼樣的人都有啊！',
-    cards: [
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      },
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      },
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      },
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      },
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      },
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      },
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      },
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      }
-    ],
-    lastOpened: 'Feb 25, 2025'
-  },
-  {
-    _id: 10,
-    title: '計畫書',
-    content:
-      '每天我要到許多地方去，也會遇到很多人。有些人喜歡叫我「左轉」、「右轉」、「停」；有些人會把髒東西留在我的車上。不過也有一些不錯的人，可以從他們身上學到很多東西，所以我也交了好幾個朋友。真是什麼樣的人都有啊！',
-    cards: [
-      {
-        text: 'asdfasdfasd',
-        status: 'active',
-        frontProperties: 'asdfasdf',
-        backProperties: 'aslfjasd;f'
-      }
-    ],
-    lastOpened: 'Feb 25, 2025'
-  },
-  {
-    _id: 11,
-    title: '開發者',
-    content:
-      '每天我要到許多地方去，也會遇到很多人。有些人喜歡叫我「左轉」、「右轉」、「停」；有些人會把髒東西留在我的車上。不過也有一些不錯的人，可以從他們身上學到很多東西，所以我也交了好幾個朋友。真是什麼樣的人都有啊！',
-    cards: [],
-    lastOpened: 'Feb 25, 2025'
-  }
-];
+import FlashcardGameModal from '../components/FlashcardGameModal/FlashcardGameModal';
 
 export default function DashboardPage() {
   const { user, loading } = useAuthContext();
@@ -301,10 +23,10 @@ export default function DashboardPage() {
   const [sortDirection, setSortDirection] = useState('asc');
   const [isAddTextOpen, setIsAddTextOpen] = useState(false);
   const [isUserDropdownOpen, setIsUserDropdownOpen] = useState(false);
+  const [isQuizModalOpen, setIsQuizModalOpen] = useState(false);
   const [openMenuId, setOpenMenuId] = useState(false);
   const [showModal, setShowModal] = useState(false);
   const [textToDelete, setTextToDelete] = useState(null);
-
   const [texts, setTexts] = useState([]);
   const dispatch = useSavedWordsDispatch();
   const { savedWords } = useSavedWordsContext();
@@ -327,7 +49,7 @@ export default function DashboardPage() {
 
   const showLessItems = (amount) => {
     if (itemsToShow > 3) {
-      setFadeOut(true); // Start fade-out animation
+      setFadeOut(true);
 
       const listContainer = document.querySelector('.dashboard__table-container');
       const firstVisibleItem = document.querySelector('.dashboard__table-container__item-row');
@@ -420,6 +142,12 @@ export default function DashboardPage() {
       </div>
     );
   };
+
+  function startQuiz() {
+    console.log('Starting Quiz');
+    console.log('Saved Words: ', savedWords);
+    setIsQuizModalOpen(true);
+  }
 
   // Fetch all Texts for the User:
   useEffect(() => {
@@ -578,7 +306,7 @@ export default function DashboardPage() {
                     iconStyling="reusable-button__icon-flip"
                     buttonVariant="tertiary"
                     buttonText="Review"
-                    buttonOnClickFunc={() => console.log('click click')}
+                    buttonOnClickFunc={startQuiz}
                   />
                 )}
             </div>
@@ -683,7 +411,7 @@ export default function DashboardPage() {
                             iconStyling="reusable-button__icon-flip"
                             buttonVariant="tertiary"
                             buttonText="Review"
-                            buttonOnClickFunc={() => console.log('click click')}
+                            buttonOnClickFunc={startQuiz}
                           />
                         )}
                         <button
@@ -766,6 +494,11 @@ export default function DashboardPage() {
         isOpen={isAddTextOpen}
         onClose={() => setIsAddTextOpen(false)}
         onSuccess={() => fetchTexts(user, setTexts)}
+      />
+      <FlashcardGameModal
+        wordList={savedWords}
+        open={isQuizModalOpen}
+        onClose={() => setIsQuizModalOpen(false)}
       />
     </div>
   );

--- a/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
+++ b/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
@@ -124,7 +124,6 @@ export default function DashboardPage() {
 
     try {
       await deleteText(textToDelete, user._id);
-      console.log('Deleted item with ID:', textToDelete);
     } catch (error) {
       console.error('Failed to delete from server:', error);
     }
@@ -144,8 +143,6 @@ export default function DashboardPage() {
   };
 
   function startQuiz() {
-    console.log('Starting Quiz');
-    console.log('Saved Words: ', savedWords);
     setIsQuizModalOpen(true);
   }
 

--- a/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
+++ b/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
@@ -493,7 +493,6 @@ export default function DashboardPage() {
         onSuccess={() => fetchTexts(user, setTexts)}
       />
       <FlashcardGameModal
-        wordList={savedWords}
         open={isQuizModalOpen}
         onClose={() => setIsQuizModalOpen(false)}
       />

--- a/client/src/KnowNativePage/TextPage/TextsPage.jsx
+++ b/client/src/KnowNativePage/TextPage/TextsPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import Slider from '../../ui-components/Slider/slider.jsx';
 import DashboardNavbar from '../components/DashboardNavbar';
@@ -16,6 +16,7 @@ export default function TextsPage() {
   const [isUserDropdownOpen, setIsUserDropdownOpen] = useState(false);
   const [text, setText] = useState(location.state?.text || null);
   const [isSliderOpen, setIsSliderOpen] = useState(false);
+  const blurRef = useRef(null);
 
   function handleTabClick(tabName) {
     setActiveTab(tabName);
@@ -29,6 +30,19 @@ export default function TextsPage() {
       </div>
     );
   }
+
+  // Function that blurs the background text when flashcard game is active.
+  function blurText (isActive) {
+
+    // Safety check to prevent errors when blurText is not defined.
+    if (!blurRef.current) return;
+
+    if (isActive) {
+      blurRef.current.style.filter = 'blur(6px)';
+    } else {
+      blurRef.current.removeAttribute('style');
+    }
+  };
 
   return (
     <div className="dashboard">
@@ -75,7 +89,7 @@ export default function TextsPage() {
         {/* Tabs for switching mode */}
         <div
           className={`text-page__layout ${isSliderOpen ? 'text-page__layout--with-sidebar' : 'text-page__layout--full-width'}`}>
-          <div className={`text-page__workspace`}>
+          <div className={`text-page__workspace`} ref={blurRef}>
             <div
               className={`${isSliderOpen ? 'tabs__compressed sticky-fade ' : 'tabs sticky-fade '}`}>
               <button
@@ -151,10 +165,7 @@ export default function TextsPage() {
             <Slider
               isOpen={isSliderOpen}
               onClose={() => setIsSliderOpen(false)}
-              onSuccess={() => {
-                // Add review logic here if needed
-                setIsSliderOpen(false);
-              }}
+              blurText={blurText}
             />
           </div>
         </div>

--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
@@ -1,9 +1,12 @@
 import { Button, Dialog, DialogActions, DialogContent } from '@mui/material';
 import { IoMdClose } from 'react-icons/io';
+import { useSavedWordsContext } from '../../../contexts/SavedWords/SavedWordsProvider';
 import './FlashcardGameModal.scss';
 
-export default function FlashcardGameModal({ wordList, selectedFront = 'chinese', showPinyin = true, open, onClose }) {
+export default function FlashcardGameModal({ selectedFront = 'chinese', showPinyin = true, open, onClose }) {
     
+    const { savedWords } = useSavedWordsContext();
+
     function handleClose() {
         onClose();
     }
@@ -48,7 +51,7 @@ export default function FlashcardGameModal({ wordList, selectedFront = 'chinese'
                 }}>
                 <div style={{ textAlign: 'center' }}>
                     <h2>Flashcards Placeholder</h2>
-                    <p>Saved Words: {wordList ? wordList.length : 0}</p>
+                    <p>Saved Words: {savedWords ? savedWords.length : 0}</p>
                     <p>Selected Front: {selectedFront}</p>
                     <p>Show Pinyin: {showPinyin ? 'Yes' : 'No'}</p>
                     <p style={{ marginTop: '20px', color: '#666' }}>

--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
@@ -1,0 +1,61 @@
+import { Button, Dialog, DialogActions, DialogContent } from '@mui/material';
+import { IoMdClose } from 'react-icons/io';
+import './FlashcardGameModal.scss';
+
+export default function FlashcardGameModal({ wordList, selectedFront = 'chinese', showPinyin = true, open, onClose }) {
+    
+    function handleClose() {
+        onClose();
+    }
+
+    return (
+        <Dialog
+            open={open}
+            onClose={handleClose}
+            transitionDuration={420}
+            PaperComponent={({ children }) => (
+                <div
+                    style={{
+                        width: '60vmin',
+                        height: '55vmin',
+                        backgroundColor: 'white',
+                        color: 'var(--drk-txt)',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        padding: '1vmin',
+                        borderRadius: '2vmin'
+                    }}>
+                    {children}
+                </div>
+            )}>
+            <DialogActions
+                style={{
+                    alignSelf: 'flex-end',
+                    padding: '0'
+                }}>
+                <Button onClick={handleClose}>
+                    <IoMdClose className="close-icon" />
+                </Button>
+            </DialogActions>
+            <DialogContent
+                style={{
+                    width: '75%',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    justifyContent: 'center',
+                    alignItems: 'center'
+                }}>
+                <div style={{ textAlign: 'center' }}>
+                    <h2>Flashcards Placeholder</h2>
+                    <p>Saved Words: {wordList ? wordList.length : 0}</p>
+                    <p>Selected Front: {selectedFront}</p>
+                    <p>Show Pinyin: {showPinyin ? 'Yes' : 'No'}</p>
+                    <p style={{ marginTop: '20px', color: '#666' }}>
+                        Flashcard.jsx component will be implemented here.
+                    </p>
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
@@ -1,15 +1,29 @@
+import { useEffect } from 'react';
 import { Button, Dialog, DialogActions, DialogContent } from '@mui/material';
 import { IoMdClose } from 'react-icons/io';
 import { useSavedWordsContext } from '../../../contexts/SavedWords/SavedWordsProvider';
 import './FlashcardGameModal.scss';
 
-export default function FlashcardGameModal({ selectedFront = 'chinese', showPinyin = true, open, onClose }) {
+export default function FlashcardGameModal({ selectedFront = 'chinese', showPinyin = true, open, onClose, blurText }) {
     
     const { savedWords } = useSavedWordsContext();
 
     function handleClose() {
         onClose();
     }
+
+    // Blur the background text when the FlashcardGameModal is open
+    useEffect(() => {
+        if (blurText) {
+            blurText(open);
+        }
+        // Remove blur when the FlashcardGameModal closes.
+        return () => {
+            if (blurText) {
+                blurText(false);
+            }
+        };
+    }, [open, blurText]);
 
     return (
         <Dialog

--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.scss
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.scss
@@ -1,0 +1,121 @@
+@mixin flex-center {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.game-modal {
+  &__play-btn {
+    margin-top: 3vmin;
+    font-size: 1.1rem;
+    padding: 1vmin 2vmin;
+    background-color: #006769;
+    color: white;
+    transition: transform 0.3s ease-in-out;
+
+    &:not(:disabled):hover {
+      background-color: var(--teal);
+      transform: scale(1.1);
+    }
+
+    &:disabled {
+      background-color: var(--medium);
+      opacity: 0.6;
+    }
+  }
+
+  &__congrats-msg {
+    @include flex-center;
+    flex-direction: column;
+  }
+}
+
+.button-container {
+  @include flex-center;
+
+  &__flip-button {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: var(--action);
+    color: white;
+    border: none;
+    border-radius: 6px;
+    padding: 10px 20px;
+    font-size: 16px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+
+    &:hover {
+      background-color: var(--medium);
+    }
+
+    &:focus {
+      outline: none;
+    }
+  }
+}
+
+.flashcard-buttons {
+  @include flex-center;
+  margin: 0;
+  gap: 2vmin;
+
+  &__correct-btn,
+  &__incorrect-btn {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1vmin;
+    padding: 1vmin 2vmin;
+  }
+
+  &__correct-btn {
+    border: 2px solid var(--action);
+    color: var(--darkest);
+    background-color: var(--action);
+    color: var(--white);
+
+    &:hover {
+      background-color: var(--medium);
+      border: 2px solid var(--medium);
+    }
+  }
+
+  &__incorrect-btn {
+    border: 2px solid var(--red-brick);
+    color: var(--red-brick);
+    background-color: var(--red-brick-transparent);
+
+    &:hover {
+      background-color: white;
+    }
+  }
+
+  &__icon {
+    font-size: 3vmin;
+  }
+}
+
+.flashcard-count {
+  @include flex-center;
+  text-align: center;
+  padding-top: 2vmin;
+  gap: 1rem;
+  margin-bottom: 2rem;
+
+  &__correct {
+    color: var(--green-drk);
+    font-weight: 800;
+  }
+
+  &__remaining {
+    color: var(--red-poppy);
+    font-weight: 800;
+  }
+
+  & p {
+    margin: 0;
+  }
+}

--- a/client/src/ui-components/Slider/slider.jsx
+++ b/client/src/ui-components/Slider/slider.jsx
@@ -192,9 +192,6 @@ const Slider = ({ isOpen, onClose, onSuccess }) => {
       onSave={handleSaveWord}
     />
     <FlashcardGameModal
-      wordList={savedWords}
-      selectedFront="chinese"
-      showPinyin={true}
       open={flashcardGameModalOpen}
       onClose={handleCloseFlashcardGameModal}
     />

--- a/client/src/ui-components/Slider/slider.jsx
+++ b/client/src/ui-components/Slider/slider.jsx
@@ -46,6 +46,7 @@ const Slider = ({ isOpen, onClose, onSuccess }) => {
   }, [isOpen, onClose]);
 
   function handleOpenFlashcardGameModal() {
+    onClose();
     setFlashcardGameModalOpen(true);
   }
 

--- a/client/src/ui-components/Slider/slider.jsx
+++ b/client/src/ui-components/Slider/slider.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import './slider.scss';
 import EditWordModal from '../../KnowNativePage/TextPage/components/EditWordModal/EditWordModal';
+import FlashcardGameModal from '../../KnowNativePage/components/FlashcardGameModal/FlashcardGameModal';
 import { FaPencilAlt, FaTrashAlt  } from 'react-icons/fa';
 import { BiDotsVerticalRounded } from 'react-icons/bi';
 import Button from '../Button/button';
@@ -18,6 +19,7 @@ const Slider = ({ isOpen, onClose, onSuccess }) => {
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [selectedWord, setSelectedWord] = useState(null);
   const [errorMessage, setErrorMessage] = useState('');
+  const [flashcardGameModalOpen, setFlashcardGameModalOpen] = useState(false);
 
   useEffect(() => {
     function handleKeyDown(event) {
@@ -42,6 +44,14 @@ const Slider = ({ isOpen, onClose, onSuccess }) => {
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [isOpen, onClose]);
+
+  function handleOpenFlashcardGameModal() {
+    setFlashcardGameModalOpen(true);
+  }
+
+  function handleCloseFlashcardGameModal() {
+    setFlashcardGameModalOpen(false);
+  }
 
   function handleOpenEditModal() {
     setShowingEditWordModal(true);
@@ -179,7 +189,7 @@ const Slider = ({ isOpen, onClose, onSuccess }) => {
                   iconStyling="reusable-button__icon-flip"
                   buttonVariant="tertiary"
                   buttonText="Review"
-                  buttonOnClickFunc={() => console.log('click click')}
+                  buttonOnClickFunc={handleOpenFlashcardGameModal}
                 />
               </div>
             )}
@@ -191,6 +201,13 @@ const Slider = ({ isOpen, onClose, onSuccess }) => {
       isOpen={editModalOpen}
       onClose={() => setEditModalOpen(false)}
       onSave={handleSaveWord}
+    />
+    <FlashcardGameModal
+      wordList={savedWords}
+      selectedFront="chinese"
+      showPinyin={true}
+      open={flashcardGameModalOpen}
+      onClose={handleCloseFlashcardGameModal}
     />
     </>
   );

--- a/client/src/ui-components/Slider/slider.jsx
+++ b/client/src/ui-components/Slider/slider.jsx
@@ -116,18 +116,6 @@ const Slider = ({ isOpen, onClose, onSuccess }) => {
           onClick={() => setActiveCardId(activeCardId === word._id ? null : word._id)}
         />
 
-        {/* 
-        Modal (demo, disabled)
-        {modalCardId === word._id && (
-          <DemoEditWordModal
-            handleDeleteWord={() => handleDeleteWord(word._id)}
-            setShowModal={(open) => setModalCardId(open ? word._id : null)}
-            updateWord={updateWord}
-            word={word}
-          />
-        )}
-        */}
-
         {/* Menu */}
         {activeCardId === word._id && (
           <article

--- a/client/src/ui-components/Slider/slider.jsx
+++ b/client/src/ui-components/Slider/slider.jsx
@@ -8,7 +8,7 @@ import Button from '../Button/button';
 import { useSavedWordsContext, useSavedWordsDispatch } from '../../contexts/SavedWords/SavedWordsProvider';
 import { updateCard } from '../../utilities/cards-api';
 
-const Slider = ({ isOpen, onClose, onSuccess }) => {
+const Slider = ({ isOpen, onClose, blurText }) => {
   const [isEditMenuOpen, setIsEditMenuOpen] = useState(false);
   const [isMouseInsideMenu, setIsMouseInsideMenu] = useState(false);
   const [showingEditWordModal, setShowingEditWordModal] = useState(false);
@@ -194,6 +194,7 @@ const Slider = ({ isOpen, onClose, onSuccess }) => {
     <FlashcardGameModal
       open={flashcardGameModalOpen}
       onClose={handleCloseFlashcardGameModal}
+      blurText={blurText}
     />
     </>
   );


### PR DESCRIPTION
 `FlashcardGameModal` is our new overlay component that will hold the Flashcard Activity.
 
It launches from both the `DashboardPage` and the `Slider` component, and receives the user's savedCards from React's Context.
 
I've also removed the mock data for cards, deleted dead code and cleaned up some `console.log` statements, but the main focus of this PR is enabling the flashcard review modal and putting a placeholder to where the `Flascard.jsx` component will be rendered in a future Pull Request.

**Flashcard Game Modal Integration:**

- Added the new `FlashcardGameModal` component, which currently displays a placeholder for future flashcard functionality and shows the count of saved words.
- Integrated `FlashcardGameModal` into `DashboardPage`, including state management for opening and closing the modal, and connected the "Review" button to launch the modal when clicked.
- Integrated `FlashcardGameModal` into the `Slider` component, allowing users to open the modal from the word list as well. 

**Code Cleanup:**

- Removed unused mock data from `DashboardPage` to reduce clutter and avoid confusion. (`client/src/KnowNativePage/DashboardPage/DashboardPage.jsx`)
- Removed an unnecessary `console.log` statement after deleting a text item. (`client/src/KnowNativePage/DashboardPage/DashboardPage.jsx`)

**UI/U:**

- Added a new SCSS stylehseet for the flashcard game modal and its buttons. This file will be used in a future Pull Request to adapt the styling to what's shown in the demo version of the app. (`client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.scss`)

These changes lay the groundwork for the implementation of the `Flashcard.jsx` component, integrating the launch of the activity into the flow.

Closes #308 