### PR TITLE
Add Flashcard #310

### DIFF
--- a/client/src/KnowNativePage/components/Flashcard/Flashcard.jsx
+++ b/client/src/KnowNativePage/components/Flashcard/Flashcard.jsx
@@ -1,0 +1,45 @@
+import './Flashcard.scss';
+
+export default function Flashcard({
+  chinese,
+  pinyin,
+  english,
+  selectedFront = 'chinese',
+  showPinyin = true,
+  isFlipped = false,
+  onToggle: _onToggle // kept for API compatibility; unused here
+}) {
+  const englishTextStyle = { fontSize: '20px' };
+
+  return (
+    <div className="flashcard">
+      <div className="flashcard__front">
+        {selectedFront === 'chinese' ? (
+          <div>
+            {showPinyin && <p className="flashcard__front--pinyin">{pinyin}</p>}
+            <p className="flashcard__front--zh zh">{chinese}</p>
+          </div>
+        ) : (
+          <div>
+            <p style={englishTextStyle}>{english}</p>
+          </div>
+        )}
+      </div>
+
+      {isFlipped && (
+        <div className="flashcard__back">
+          {selectedFront === 'english' ? (
+            <div>
+              {showPinyin && <p className="flashcard__back--pinyin">{pinyin}</p>}
+              <p className="flashcard__back--zh zh">{chinese}</p>
+            </div>
+          ) : (
+            <div>
+              <p style={englishTextStyle}>{english}</p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/KnowNativePage/components/Flashcard/Flashcard.scss
+++ b/client/src/KnowNativePage/components/Flashcard/Flashcard.scss
@@ -1,0 +1,35 @@
+.flashcard {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border-radius: 1vmin;
+  box-shadow: none;
+  height: auto;
+  overflow: hidden;
+  margin: 0 auto;
+  min-height: 22vmin;
+
+  &__front,
+  &__back {
+    padding: 1rem;
+    width: 100%;
+    height: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    font-size: 4vmin;
+    border-radius: 1vmin;
+    border: none;
+
+    &--pinyin {
+      font-size: 2vmin;
+      margin: auto;
+    }
+  }
+
+  &__front { margin-bottom: -20px; }
+  &__back  { border-top: 0.5px solid var(--dark); border-radius: 0; }
+}

--- a/client/src/KnowNativePage/components/Flashcard/Flashcard.scss
+++ b/client/src/KnowNativePage/components/Flashcard/Flashcard.scss
@@ -30,6 +30,7 @@
     }
   }
 
+  // Pulls the front and back together so the seam looks like one card
   &__front { margin-bottom: -20px; }
   &__back  { border-top: 0.5px solid var(--dark); border-radius: 0; }
 }

--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
@@ -1,12 +1,32 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Button, Dialog, DialogActions, DialogContent } from '@mui/material';
 import { IoMdClose } from 'react-icons/io';
 import { useSavedWordsContext } from '../../../contexts/SavedWords/SavedWordsProvider';
 import './FlashcardGameModal.scss';
+import Flashcard from '../Flashcard/Flashcard';
 
 export default function FlashcardGameModal({ selectedFront = 'chinese', showPinyin = true, open, onClose, blurText }) {
     
     const { savedWords } = useSavedWordsContext();
+    const [isFlipped, setIsFlipped] = useState(false);
+
+    const w = Array.isArray(savedWords) && savedWords.length ? savedWords[0] : null;
+
+    const chinese =
+        w?.frontProperties?.traditional ??
+        w?.charGroup ??
+        w?.traditional ??
+        '';
+
+    const pinyin =
+        w?.frontProperties?.pinyin ??
+        w?.pinyin ??
+        '';
+
+    const english =
+        w?.backProperties?.meaning ??
+        w?.meaning ??
+        '';
 
     function handleClose() {
         onClose();
@@ -63,16 +83,25 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
                     justifyContent: 'center',
                     alignItems: 'center'
                 }}>
-                <div style={{ textAlign: 'center' }}>
-                    <h2>Flashcards Placeholder</h2>
-                    <p>Saved Words: {savedWords ? savedWords.length : 0}</p>
-                    <p>Selected Front: {selectedFront}</p>
-                    <p>Show Pinyin: {showPinyin ? 'Yes' : 'No'}</p>
-                    <p style={{ marginTop: '20px', color: '#666' }}>
-                        Flashcard.jsx component will be implemented here.
-                    </p>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', alignItems: 'center', textAlign: 'center' }}>
+                    <Flashcard
+                        chinese={chinese}
+                        pinyin={pinyin}
+                        english={english}
+                        selectedFront={selectedFront}
+                        showPinyin={showPinyin}
+                        isFlipped={isFlipped}
+                        onToggle={() => setIsFlipped(v => !v)}
+                    />
+                    <button
+                        type="button"
+                        className="button-container__flip-button"
+                        onClick={() => setIsFlipped(v => !v)}
+                    >
+                    {isFlipped ? 'Hide Answer' : 'Show Answer'}
+                    </button>
                 </div>
-            </DialogContent>
+                </DialogContent>
         </Dialog>
     );
 }


### PR DESCRIPTION
Fixes #310 
- Added Flashcard.jsx + Flashcard.scss (presentational)
- Render savedWords in Flashcard; modal owns isFlipped
- X to close modal and Show/Hide are clickable; no game logic

Side note, while testing noticed the DashboardPage has a duplicate profile menu. Please let me know any edits to make and if you would like me to fix DashboardPage in this issue. Thank you.

<img width="1161" height="735" alt="image1" src="https://github.com/user-attachments/assets/743e2efe-1907-447d-a415-cdc6b9114740" />
<img width="1142" height="735" alt="image2" src="https://github.com/user-attachments/assets/8918eb51-537e-4810-8306-d3c5983c7871" />
