### PR TITLE
Flashcard Navigation Logic: Shuffle, Game Progress and Navigation.

### DIFF
--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
@@ -10,6 +10,7 @@ import Flashcard from '../Flashcard/Flashcard';
 export default function FlashcardGameModal({ selectedFront = 'chinese', showPinyin = true, open, onClose, blurText }) {
     
     const { savedWords } = useSavedWordsContext();
+    const [correctCount, setCorrectCount] = useState(0);
     const [isFlipped, setIsFlipped] = useState(false);
 
     const w = Array.isArray(savedWords) && savedWords.length ? savedWords[0] : null;
@@ -85,7 +86,6 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
                     justifyContent: 'center',
                     alignItems: 'center'
                 }}>
-                <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', alignItems: 'center', textAlign: 'center' }}>
                     <Flashcard
                         chinese={chinese}
                         pinyin={pinyin}
@@ -114,8 +114,6 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
                             onClick={() => setIsFlipped(v => !v)}
                         >Show Answer
                         </button>}
-                    
-                </div>
                 </DialogContent>
         </Dialog>
     );

--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
@@ -53,17 +53,19 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
     function handleCorrect() {
         // If the user marks the card as correct, update the count.
         setCorrectCount((count) => count + 1);
-        // Remove the card marked as correct from the flashcards array.
+        // Remove the card marked as *Correct* from the flashcards array.
         setFlashcards((cards) => cards.slice(1));
         // Decrement the remaining cards counter.
         setRemainingCount((count) => count - 1);
         setIsFlipped(false);
     }
 
-    function handleIncorrect() {
-        // If the user marks the card as incorrect, flip the card back.
-        setIsFlipped(false);
-    }
+function handleIncorrect() {
+    // Create a new array by removing the first card and adding it to the end
+    setFlashcards((cards) => [...cards.slice(1), cards[0]]);
+    // Reset the flip state so the user can try the next card.
+    setIsFlipped(false);
+}
 
     return (
         <Dialog

--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
@@ -11,6 +11,7 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
     
     const { savedWords } = useSavedWordsContext();
     const [correctCount, setCorrectCount] = useState(0);
+    const [remainingCount, setRemainingCount] = useState(0);
     const [isFlipped, setIsFlipped] = useState(false);
 
     const w = Array.isArray(savedWords) && savedWords.length ? savedWords[0] : null;
@@ -96,7 +97,6 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
                         isFlipped={isFlipped}
                         onToggle={() => setIsFlipped(v => !v)}
                     />
-                    
                     {isFlipped ? 
                         <div className="flashcard-buttons">
                             <button className="flashcard-buttons__correct-btn" onClick={() => console.log("Correct clicked")}>
@@ -116,6 +116,14 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
                         >Show Answer
                         </button>
                     }
+                    <div className="flashcard-count">
+                        <p>
+                            <span className="flashcard-count__correct">{correctCount}</span> Correct
+                        </p>
+                        <p>
+                            <span className="flashcard-count__remaining">{remainingCount}</span> Remaining
+                        </p>
+                    </div>
                 </DialogContent>
         </Dialog>
     );

--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
@@ -14,7 +14,12 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
     const [correctCount, setCorrectCount] = useState(0);
     const [remainingCount, setRemainingCount] = useState(0);
     const [isFlipped, setIsFlipped] = useState(false);
-    const [hasBeenFlipped, setHasBeenFlipped] = useState(false);
+
+    const word = Array.isArray(flashcards) && flashcards.length ? flashcards[0] : null;
+
+    const chinese = word?.frontProperties.traditional
+    const pinyin = word?.frontProperties.pinyin
+    const english = word?.backProperties.meaning
 
     function shuffle(cards) {
         // Shuffle the cards using the Fisher-Yates algorithm:
@@ -28,12 +33,12 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
 
     // ** When the modal opens:** 
     // 1) Initialize and shuffle the flashcards array with all of the savedWords.
+    // 2) Set the remaining count to the total number of savedWords.
     useEffect(() => {
     if (open && savedWords.length > 0) {
         const allCards = [...savedWords];
         shuffle(allCards);
         setFlashcards(allCards);
-        // 2) Set the remaining count to the total number of savedWords.
         setRemainingCount(savedWords.length);
     }
     }, [open, savedWords]);
@@ -43,51 +48,40 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
         if (blurText) {
             blurText(open);
         }
-        // Remove blur when the FlashcardGameModal closes.
+        // Remove text blur when the FlashcardGameModal closes.
         return () => {
             if (blurText) {
                 blurText(false);
             }
         };
     }, [open, blurText]);
-
-    const word = Array.isArray(flashcards) && flashcards.length ? flashcards[0] : null;
-
-    const chinese = word?.frontProperties.traditional
-    const pinyin = word?.frontProperties.pinyin
-    const english = word?.backProperties.meaning
     
     function handleClose() {
         setFlashcards([]);
         setCorrectCount(0);
-        setHasBeenFlipped(false);
         onClose();
     }
     
     function handleCorrect() {
-        // If the user marks the card as correct, update the count.
-        setCorrectCount((count) => count + 1);
+        // If the user marks the card as correct:
+        // Update the count.
         // Remove the card marked as *Correct* from the flashcards array.
-        setFlashcards((cards) => cards.slice(1));
         // Decrement the remaining cards counter.
+        setCorrectCount((count) => count + 1);
+        setFlashcards((cards) => cards.slice(1));
         setRemainingCount((count) => count - 1);
         setIsFlipped(false);
-        setHasBeenFlipped(false);
     }
 
     function handleIncorrect() {
-        // Create a new array by removing the first card and adding it to the end
+        // If the user marks the word as incorrect:
+        // Create a new array by removing the first card and adding it to the end of the array.
         setFlashcards((cards) => [...cards.slice(1), cards[0]]);
-        // Reset the flip state so the user can try the next card.
         setIsFlipped(false);
-        setHasBeenFlipped(false);
     }
 
   function handleToggle() {
         setIsFlipped(!isFlipped);
-        if (!hasBeenFlipped) {
-        setHasBeenFlipped(true);
-        }
     }
 
     return (
@@ -135,7 +129,6 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
                         selectedFront={selectedFront}
                         showPinyin={showPinyin}
                         isFlipped={isFlipped}
-                        onToggle={handleToggle}
                     />
                     {isFlipped ? 
                         <div className="flashcard-buttons">

--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
@@ -14,6 +14,7 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
     const [correctCount, setCorrectCount] = useState(0);
     const [remainingCount, setRemainingCount] = useState(0);
     const [isFlipped, setIsFlipped] = useState(false);
+    const [hasBeenFlipped, setHasBeenFlipped] = useState(false);
 
     // ** When the modal opens:** 
     // 1) Initialize the flashcards array with all of the savedWords.
@@ -23,7 +24,7 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
         // 2) Set the remaining count to the total number of savedWords.
         setRemainingCount(savedWords.length);
     }
-}, [open, savedWords]);
+    }, [open, savedWords]);
 
     // 3) Blur the background text
     useEffect(() => {
@@ -58,14 +59,23 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
         // Decrement the remaining cards counter.
         setRemainingCount((count) => count - 1);
         setIsFlipped(false);
+        setHasBeenFlipped(false);
     }
 
-function handleIncorrect() {
-    // Create a new array by removing the first card and adding it to the end
-    setFlashcards((cards) => [...cards.slice(1), cards[0]]);
-    // Reset the flip state so the user can try the next card.
-    setIsFlipped(false);
-}
+    function handleIncorrect() {
+        // Create a new array by removing the first card and adding it to the end
+        setFlashcards((cards) => [...cards.slice(1), cards[0]]);
+        // Reset the flip state so the user can try the next card.
+        setIsFlipped(false);
+        setHasBeenFlipped(false);
+    }
+
+  function handleToggle() {
+        setIsFlipped(!isFlipped);
+        if (!hasBeenFlipped) {
+        setHasBeenFlipped(true);
+        }
+    }
 
     return (
         <Dialog
@@ -112,7 +122,7 @@ function handleIncorrect() {
                         selectedFront={selectedFront}
                         showPinyin={showPinyin}
                         isFlipped={isFlipped}
-                        onToggle={() => setIsFlipped(v => !v)}
+                        onToggle={handleToggle}
                     />
                     {isFlipped ? 
                         <div className="flashcard-buttons">
@@ -129,7 +139,7 @@ function handleIncorrect() {
                         <button
                             type="button"
                             className="button-container__flip-button"
-                            onClick={() => setIsFlipped(v => !v)}
+                            onClick={() => setIsFlipped(isFlipped => !isFlipped)}
                         >Show Answer
                         </button>
                     }

--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
@@ -34,7 +34,14 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
 
     function handleClose() {
         setIsFlipped(false);
+        setCorrectCount(0);
         onClose();
+    }
+    
+    function handleCorrect() {
+        // If the user marks the card as correct, update the count.
+        setCorrectCount((prev) => prev + 1);
+        setIsFlipped(false);
     }
 
     // Blur the background text when the FlashcardGameModal is open
@@ -99,7 +106,7 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
                     />
                     {isFlipped ? 
                         <div className="flashcard-buttons">
-                            <button className="flashcard-buttons__correct-btn" onClick={() => console.log("Correct clicked")}>
+                            <button className="flashcard-buttons__correct-btn" onClick={handleCorrect}>
                                 <GiCheckMark className="flashcard-buttons__icon" />
                                 Correct!
                             </button>

--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
@@ -17,9 +17,9 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
 
     const word = Array.isArray(flashcards) && flashcards.length ? flashcards[0] : null;
 
-    const chinese = word?.frontProperties.traditional
-    const pinyin = word?.frontProperties.pinyin
-    const english = word?.backProperties.meaning
+    const chinese = word?.frontProperties.traditional;
+    const pinyin = word?.frontProperties.pinyin;
+    const english = word?.backProperties.meaning;
 
     function shuffle(cards) {
         // Shuffle the cards using the Fisher-Yates algorithm:

--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
@@ -44,6 +44,11 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
         setIsFlipped(false);
     }
 
+    function handleIncorrect() {
+        // If the user marks the card as incorrect, flip the card back.
+        setIsFlipped(false);
+    }
+
     // Blur the background text when the FlashcardGameModal is open
     useEffect(() => {
         if (blurText) {
@@ -110,7 +115,7 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
                                 <GiCheckMark className="flashcard-buttons__icon" />
                                 Correct!
                             </button>
-                            <button className="flashcard-buttons__incorrect-btn" onClick={() => console.log("Incorrect clicked")}>
+                            <button className="flashcard-buttons__incorrect-btn" onClick={handleIncorrect}>
                                 <PiRepeatBold className="flashcard-buttons__icon" />
                                 Try again
                             </button>

--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
@@ -32,6 +32,7 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
         '';
 
     function handleClose() {
+        setIsFlipped(false);
         onClose();
     }
 
@@ -113,7 +114,8 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
                             className="button-container__flip-button"
                             onClick={() => setIsFlipped(v => !v)}
                         >Show Answer
-                        </button>}
+                        </button>
+                    }
                 </DialogContent>
         </Dialog>
     );

--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { Button, Dialog, DialogActions, DialogContent } from '@mui/material';
 import { IoMdClose } from 'react-icons/io';
+import { GiCheckMark } from 'react-icons/gi';
+import { PiRepeatBold } from 'react-icons/pi';
 import { useSavedWordsContext } from '../../../contexts/SavedWords/SavedWordsProvider';
 import './FlashcardGameModal.scss';
 import Flashcard from '../Flashcard/Flashcard';
@@ -93,13 +95,26 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
                         isFlipped={isFlipped}
                         onToggle={() => setIsFlipped(v => !v)}
                     />
-                    <button
-                        type="button"
-                        className="button-container__flip-button"
-                        onClick={() => setIsFlipped(v => !v)}
-                    >
-                    {isFlipped ? 'Hide Answer' : 'Show Answer'}
-                    </button>
+                    
+                    {isFlipped ? 
+                        <div className="flashcard-buttons">
+                            <button className="flashcard-buttons__correct-btn" onClick={() => console.log("Correct clicked")}>
+                                <GiCheckMark className="flashcard-buttons__icon" />
+                                Correct!
+                            </button>
+                            <button className="flashcard-buttons__incorrect-btn" onClick={() => console.log("Incorrect clicked")}>
+                                <PiRepeatBold className="flashcard-buttons__icon" />
+                                Try again
+                            </button>
+                        </div> 
+                        : 
+                        <button
+                            type="button"
+                            className="button-container__flip-button"
+                            onClick={() => setIsFlipped(v => !v)}
+                        >Show Answer
+                        </button>}
+                    
                 </div>
                 </DialogContent>
         </Dialog>

--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
@@ -16,11 +16,23 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
     const [isFlipped, setIsFlipped] = useState(false);
     const [hasBeenFlipped, setHasBeenFlipped] = useState(false);
 
+    function shuffle(cards) {
+        // Shuffle the cards using the Fisher-Yates algorithm:
+        let i = cards.length;
+        while (i > 0) {
+            let newIdx = Math.floor(Math.random() * i);
+            i--;
+            [cards[newIdx], cards[i]] = [cards[i], cards[newIdx]];
+        }
+    }
+
     // ** When the modal opens:** 
-    // 1) Initialize the flashcards array with all of the savedWords.
+    // 1) Initialize and shuffle the flashcards array with all of the savedWords.
     useEffect(() => {
     if (open && savedWords.length > 0) {
-        setFlashcards([...savedWords]);
+        const allCards = [...savedWords];
+        shuffle(allCards);
+        setFlashcards(allCards);
         // 2) Set the remaining count to the total number of savedWords.
         setRemainingCount(savedWords.length);
     }
@@ -44,10 +56,11 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
     const chinese = word?.frontProperties.traditional
     const pinyin = word?.frontProperties.pinyin
     const english = word?.backProperties.meaning
-
+    
     function handleClose() {
-        setIsFlipped(false);
+        setFlashcards([]);
         setCorrectCount(0);
+        setHasBeenFlipped(false);
         onClose();
     }
     
@@ -139,7 +152,7 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
                         <button
                             type="button"
                             className="button-container__flip-button"
-                            onClick={() => setIsFlipped(isFlipped => !isFlipped)}
+                            onClick={handleToggle}
                         >Show Answer
                         </button>
                     }

--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
@@ -10,46 +10,22 @@ import Flashcard from '../Flashcard/Flashcard';
 export default function FlashcardGameModal({ selectedFront = 'chinese', showPinyin = true, open, onClose, blurText }) {
     
     const { savedWords } = useSavedWordsContext();
+    const [flashcards, setFlashcards] = useState([]);
     const [correctCount, setCorrectCount] = useState(0);
     const [remainingCount, setRemainingCount] = useState(0);
     const [isFlipped, setIsFlipped] = useState(false);
 
-    const w = Array.isArray(savedWords) && savedWords.length ? savedWords[0] : null;
-
-    const chinese =
-        w?.frontProperties?.traditional ??
-        w?.charGroup ??
-        w?.traditional ??
-        '';
-
-    const pinyin =
-        w?.frontProperties?.pinyin ??
-        w?.pinyin ??
-        '';
-
-    const english =
-        w?.backProperties?.meaning ??
-        w?.meaning ??
-        '';
-
-    function handleClose() {
-        setIsFlipped(false);
-        setCorrectCount(0);
-        onClose();
+    // ** When the modal opens:** 
+    // 1) Initialize the flashcards array with all of the savedWords.
+    useEffect(() => {
+    if (open && savedWords.length > 0) {
+        setFlashcards([...savedWords]);
+        // 2) Set the remaining count to the total number of savedWords.
+        setRemainingCount(savedWords.length);
     }
-    
-    function handleCorrect() {
-        // If the user marks the card as correct, update the count.
-        setCorrectCount((prev) => prev + 1);
-        setIsFlipped(false);
-    }
+}, [open, savedWords]);
 
-    function handleIncorrect() {
-        // If the user marks the card as incorrect, flip the card back.
-        setIsFlipped(false);
-    }
-
-    // Blur the background text when the FlashcardGameModal is open
+    // 3) Blur the background text
     useEffect(() => {
         if (blurText) {
             blurText(open);
@@ -61,6 +37,33 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
             }
         };
     }, [open, blurText]);
+
+    const word = Array.isArray(flashcards) && flashcards.length ? flashcards[0] : null;
+
+    const chinese = word?.frontProperties.traditional
+    const pinyin = word?.frontProperties.pinyin
+    const english = word?.backProperties.meaning
+
+    function handleClose() {
+        setIsFlipped(false);
+        setCorrectCount(0);
+        onClose();
+    }
+    
+    function handleCorrect() {
+        // If the user marks the card as correct, update the count.
+        setCorrectCount((count) => count + 1);
+        // Remove the card marked as correct from the flashcards array.
+        setFlashcards((cards) => cards.slice(1));
+        // Decrement the remaining cards counter.
+        setRemainingCount((count) => count - 1);
+        setIsFlipped(false);
+    }
+
+    function handleIncorrect() {
+        // If the user marks the card as incorrect, flip the card back.
+        setIsFlipped(false);
+    }
 
     return (
         <Dialog


### PR DESCRIPTION
This PR continues our work on the flashcard game in the `FlashcardGameModal` component by adding deck shuffling, and progress tracking UI.

The modal now supports:
- Shufflling cards on open
- Marking cards as correct or incorrect
- Displaying progress counters.

Basically matching most of the functionality we have in the Demo version of the app.

Closes #312 

**Flashcard game logic:**

* Added state and logic to manage a shuffled flashcard deck, track the number of correct answers, and count remaining cards. Users can now mark cards as _correct_ (removing them from the deck and incrementing the correct count) or _incorrect_ (moving them to the end of the deck).
* Implemented the demo's `shuffle()` function to randomize the order of flashcards each time the modal opens.
* Added buttons for marking answers as correct or incorrect (try again).

**Modal Cleanup:**
* Flashcard state is reset and background blur is removed when the modal closes.

**What's not in scope:**
* Finalizing the game with a _Congratulations_ screen and a _Play Again_ button. This should be addressed in a future PR.