### PR TITLE
Flashcard activity styling #314

### DIFF
--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
@@ -14,6 +14,7 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
     const [correctCount, setCorrectCount] = useState(0);
     const [remainingCount, setRemainingCount] = useState(0);
     const [isFlipped, setIsFlipped] = useState(false);
+    const [isClosing, setIsClosing] = useState(false);
 
     // Refs for focus management
     const modalRef = useRef(null);
@@ -28,6 +29,8 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
     const chinese = word?.frontProperties.traditional;
     const pinyin = word?.frontProperties.pinyin;
     const english = word?.backProperties.meaning;
+
+    const showGame = open && remainingCount > 0;
 
     function shuffle(cards) {
         // Shuffle the cards using the Fisher-Yates algorithm:
@@ -154,6 +157,7 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
     }, [open, isFlipped, remainingCount]);
     
     function handleClose() {
+        setIsClosing(true);
         setFlashcards([]);
         setCorrectCount(0);
         setRemainingCount(0);
@@ -191,8 +195,6 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
   function handleToggle() {
         setIsFlipped(!isFlipped);
     }
-
-    const showGame = remainingCount > 0;
 
     return (
         <Dialog
@@ -281,25 +283,27 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
                     </div>
                     </> 
                 ) : (
-                    <div className="game-modal__congrats-msg">
-                        <div>
-                            <dotlottie-player
-                                src="https://lottie.host/9279b8f8-2d84-4077-aaf6-db967f8ec7bb/3JRYmBPJgq.json"
-                                background="transparent"
-                                speed="1"
-                                style={{ height: '20vmin' }}
-                                loop
-                                autoplay>
-                            </dotlottie-player>
+                    !isClosing && remainingCount === 0 && (
+                        <div className="game-modal__congrats-msg">
+                            <div>
+                                <dotlottie-player
+                                    src="https://lottie.host/9279b8f8-2d84-4077-aaf6-db967f8ec7bb/3JRYmBPJgq.json"
+                                    background="transparent"
+                                    speed="1"
+                                    style={{ height: '20vmin' }}
+                                    loop
+                                    autoplay>
+                                </dotlottie-player>
+                            </div>
+                            <h2>You completed the deck!</h2>
+                            <button 
+                                ref={playAgainButtonRef}
+                                className="game-modal__play-btn" 
+                                onClick={handlePlayAgain}>
+                                Play Again
+                            </button>
                         </div>
-                        <h2>You completed the deck!</h2>
-                        <button 
-                            ref={playAgainButtonRef}
-                            className="game-modal__play-btn" 
-                            onClick={handlePlayAgain}>
-                            Play Again
-                        </button>
-                    </div>
+                    )
                 )}
                 </DialogContent>
         </Dialog>

--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
@@ -85,7 +85,7 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
                 }
                 break;
         }
-    }, [open, isFlipped, remainingCount]);
+    }, [open, isFlipped, remainingCount, handleClose, handleToggle, handleCorrect, handleIncorrect, handlePlayAgain]);
 
     // Handler for when the user clicks outside the modal:
     const handleClickOutside = useCallback((event) => {

--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef, useCallback, useLayoutEffect } from 'react';
 import { Button, Dialog, DialogActions, DialogContent } from '@mui/material';
 import { IoMdClose } from 'react-icons/io';
 import { GiCheckMark } from 'react-icons/gi';
@@ -15,6 +15,14 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
     const [remainingCount, setRemainingCount] = useState(0);
     const [isFlipped, setIsFlipped] = useState(false);
 
+    // Refs for focus management
+    const modalRef = useRef(null);
+    const closeButtonRef = useRef(null);
+    const flipButtonRef = useRef(null);
+    const correctButtonRef = useRef(null);
+    const incorrectButtonRef = useRef(null);
+    const playAgainButtonRef = useRef(null);
+
     const word = Array.isArray(flashcards) && flashcards.length ? flashcards[0] : null;
 
     const chinese = word?.frontProperties.traditional;
@@ -30,6 +38,58 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
             [cards[newIdx], cards[i]] = [cards[i], cards[newIdx]];
         }
     }
+
+    // Handler for keyboard navigation
+    const handleKeyDown = useCallback((event) => {
+        if (!open) return;
+
+        switch (event.key) {
+            // ESC key closes the modal.
+            case 'Escape':
+                event.preventDefault();
+                handleClose();
+                break;
+            
+            // If the card is flipped, ENTER marks the card as *correct*.
+            // If the game is complete, ENTER hits *play again*.    
+            case 'Enter':
+                event.preventDefault();
+                if (remainingCount > 0) {
+                    if (!isFlipped) {
+                        handleToggle();
+                    } else {
+                        
+                        handleCorrect();
+                    }
+                } else {
+                    handlePlayAgain();
+                }
+                break;
+
+            // The user can use the left arrow to "Try Again"
+            case 'ArrowLeft':
+                event.preventDefault();
+                if (isFlipped && remainingCount > 0) {
+                    handleIncorrect();
+                }
+                break;
+            
+            // Using the right arrow, marks the word as correct.
+            case 'ArrowRight':
+                event.preventDefault();
+                if (isFlipped && remainingCount > 0) {
+                    handleCorrect();
+                }
+                break;
+        }
+    }, [open, isFlipped, remainingCount]);
+
+    // Handler for when the user clicks outside the modal:
+    const handleClickOutside = useCallback((event) => {
+        if (modalRef.current && !modalRef.current.contains(event.target)) {
+            handleClose();
+        }
+    }, []);
 
     // ** When the modal opens:** 
     // 1) Initialize and shuffle the flashcards array with all of the savedWords.
@@ -57,6 +117,41 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
             }
         };
     }, [open, blurText]);
+
+    // Add keyboard and click event listeners
+    useEffect(() => {
+        if (open) {
+            document.addEventListener('keydown', handleKeyDown);
+            document.addEventListener('mousedown', handleClickOutside);
+        }
+
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+            document.removeEventListener('mousedown', handleClickOutside);
+        };
+    }, [open, handleKeyDown, handleClickOutside]);
+
+    // When the modal opens, focus switches to the modal.
+    useLayoutEffect(() => {
+        if (open && modalRef.current) {
+            modalRef.current.focus();
+        }
+    }, [open]);
+
+    // Focus management for the buttons:
+    useLayoutEffect(() => {
+        if (!open) return;
+
+        if (remainingCount > 0) {
+            if (!isFlipped && flipButtonRef.current) {
+                flipButtonRef.current.focus();
+            } else if (isFlipped && correctButtonRef.current) {
+                correctButtonRef.current.focus();
+            }
+        } else if (remainingCount === 0 && playAgainButtonRef.current) {
+            playAgainButtonRef.current.focus();
+        }
+    }, [open, isFlipped, remainingCount]);
     
     function handleClose() {
         setFlashcards([]);
@@ -106,6 +201,7 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
             transitionDuration={420}
             PaperComponent={({ children }) => (
                 <div
+                    ref={modalRef}
                     style={{
                         width: '60vmin',
                         height: '55vmin',
@@ -125,7 +221,9 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
                     alignSelf: 'flex-end',
                     padding: '0'
                 }}>
-                <Button onClick={handleClose}>
+                <Button 
+                    ref={closeButtonRef} 
+                    onClick={handleClose}>
                     <IoMdClose className="close-icon" />
                 </Button>
             </DialogActions>
@@ -149,17 +247,24 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
                     />
                     {isFlipped ? 
                         <div className="flashcard-buttons">
-                            <button className="flashcard-buttons__correct-btn" onClick={handleCorrect}>
+                            <button 
+                                ref={correctButtonRef}
+                                className="flashcard-buttons__correct-btn"
+                                onClick={handleCorrect}>
                                 <GiCheckMark className="flashcard-buttons__icon" />
                                 Correct!
                             </button>
-                            <button className="flashcard-buttons__incorrect-btn" onClick={handleIncorrect}>
+                            <button 
+                                ref={incorrectButtonRef}
+                                className="flashcard-buttons__incorrect-btn"
+                                onClick={handleIncorrect}>
                                 <PiRepeatBold className="flashcard-buttons__icon" />
                                 Try again
                             </button>
                         </div> 
                         : 
                         <button
+                            ref={flipButtonRef}
                             type="button"
                             className="button-container__flip-button"
                             onClick={handleToggle}
@@ -188,7 +293,10 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
                             </dotlottie-player>
                         </div>
                         <h2>You completed the deck!</h2>
-                        <button className="game-modal__play-btn" onClick={handlePlayAgain}>
+                        <button 
+                            ref={playAgainButtonRef}
+                            className="game-modal__play-btn" 
+                            onClick={handlePlayAgain}>
                             Play Again
                         </button>
                     </div>

--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
@@ -105,6 +105,7 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
         setRemainingCount(allCards.length);
         setCorrectCount(0);
         setIsFlipped(false);
+        setIsClosing(false);
     }
     }, [open, savedWords]);
 
@@ -190,6 +191,7 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
         setCorrectCount(0);
         setRemainingCount(allCards.length);
         setIsFlipped(false);
+        setIsClosing(false);
     }
 
   function handleToggle() {

--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
@@ -92,7 +92,7 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
         if (modalRef.current && !modalRef.current.contains(event.target)) {
             handleClose();
         }
-    }, []);
+    }, [handleClose]);
 
     // ** When the modal opens:** 
     // 1) Initialize and shuffle the flashcards array with all of the savedWords.


### PR DESCRIPTION
We are adding keyboard navigation to the `FlashcardGameModal` component and a minor fix to the modal behavior when closing.

### Keyboard Navigation Improvements:
* Added keyboard event handling for navigation and actions (Escape to close, Enter to flip/mark correct/play again, Arrow keys for correct/incorrect).
* Implemented focus management using `useRef` and `useLayoutEffect` so that interactive elements (modal, close, flip, correct/incorrect, play again buttons) go inito focus at appropriate times.

### Modal Behavior and bug fixes:
* Added logic to close the modal when clicking outside of it.
* Prevented the _congratulations_ message from flashing when the modal is closing by tracking the closing state with `isClosing`.

This PR closes #314 