### PR TITLE
Remove footer links and add dynamic copyright year

### DIFF
--- a/client/src/LandingPages/components/LandingPageFooter/LandingPageFooter.jsx
+++ b/client/src/LandingPages/components/LandingPageFooter/LandingPageFooter.jsx
@@ -1,19 +1,13 @@
 import './LandingPageFooter.scss';
 
 export default function LandingPageFooter({ showLinks = false }) {
+  const year = new Date().getFullYear();
+
   return (
     <div className="container footer">
       <footer className="py-3 my-4">
-        {showLinks && (
-          <div className="footer-links mb-3">
-            <a href="/features" className="footer-link mx-3">Features</a>
-            <a href="/pricing" className="footer-link mx-3">Pricing</a>
-            <a href="/faqs" className="footer-link mx-3">FAQs</a>
-            <a href="/about" className="footer-link mx-3">About</a>
-          </div>
-        )}
-        <hr className="footer-divider" />
-        <p className="text-center text-body-secondary">© 2024 KnowNative</p>
+          <hr className="footer-divider" />
+        <p className="text-center text-body-secondary">© {year} KnowNative</p>
       </footer>
     </div>
   );


### PR DESCRIPTION
closes #320

- Remove landing page inactive footer links
- Added dynamic copyright year

<img width="245" height="57" alt="image1" src="https://github.com/user-attachments/assets/d4235498-f49e-4267-8209-e2cc1ba69c1d" />

