### PR TITLE
Center Dashboard. Fix alignment issue #343

### DIFF
--- a/client/src/KnowNativePage/DashboardPage/DashboardPage.scss
+++ b/client/src/KnowNativePage/DashboardPage/DashboardPage.scss
@@ -24,6 +24,7 @@ $icon-colors: (
 
 .dashboard {
     display: flex;
+    justify-content: center;
     max-height: 100vh;
 
     &--text-red {


### PR DESCRIPTION
Just a small style change to the dashboard layout.

This update centers the dashboard content horizontally by adding `justify-content: center` to the `.dashboard` class in `DashboardPage.scss`, to fix #343

<img width="3439" height="1436" alt="image" src="https://github.com/user-attachments/assets/716c34e7-bce9-4f70-beb8-9d8b982f3bec" />
