### PR TITLE
Add equal left and right padding to dashboard__main

### DIFF
--- a/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
+++ b/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
@@ -282,14 +282,14 @@ export default function DashboardPage() {
             <div className="dashboard__title dashboard__title--subtitle">
               <h4>Jump back in</h4>
             </div>
-            <div className="dashboard dashboard__card">
+            <div className="dashboard__card">
               <div className="dashboard__card__sub-container">
                 <div className="dashboard__card__icon">
                   <RoundIcon iconName="book_2" color="teal" />
                 </div>
                 <div className="dashboard__card__last-opened-content">
                   <h2 className="dashboard__card-title">開計程車</h2>
-                  <p className="dashboard dashboard__card-body">
+                  <p className="dashboard__card-body">
                     每天我要到許多地方去，也會遇到很多人。有些人喜歡叫我「左轉」、「右轉」、「停」；
                     有些人會把髒東西留在我的車上。不過也有一些不錯的人，可以從他們身上學到很多東西，
                     所以我也交了好幾個朋友。真是什麼樣的人都有啊！

--- a/client/src/KnowNativePage/DashboardPage/DashboardPage.scss
+++ b/client/src/KnowNativePage/DashboardPage/DashboardPage.scss
@@ -53,7 +53,6 @@ $icon-colors: (
     &__main{
         display: flex;
         flex-direction: column;
-        width: calc(100vw - 285px); // factors in space taken from nav
         max-width: 1500px;
         margin-inline: auto;
         padding: 0 2rem;

--- a/client/src/KnowNativePage/DashboardPage/DashboardPage.scss
+++ b/client/src/KnowNativePage/DashboardPage/DashboardPage.scss
@@ -24,7 +24,7 @@ $icon-colors: (
 
 .dashboard {
     display: flex;
-    max-height: 100vh;
+    min-height: 100vh;
 
     &--text-red {
         color: var(--red);

--- a/client/src/KnowNativePage/DashboardPage/DashboardPage.scss
+++ b/client/src/KnowNativePage/DashboardPage/DashboardPage.scss
@@ -25,6 +25,7 @@ $icon-colors: (
 .dashboard {
     display: flex;
     min-height: 100vh;
+    flex: 1;
 
     &--text-red {
         color: var(--red);

--- a/client/src/KnowNativePage/DashboardPage/DashboardPage.scss
+++ b/client/src/KnowNativePage/DashboardPage/DashboardPage.scss
@@ -56,6 +56,7 @@ $icon-colors: (
         width: calc(100vw - 285px); // factors in space taken from nav
         max-width: 1500px;
         margin-inline: auto;
+        padding: 0 2rem;
     }
 
     &__user{

--- a/client/src/KnowNativePage/DashboardPage/DashboardPage.scss
+++ b/client/src/KnowNativePage/DashboardPage/DashboardPage.scss
@@ -25,7 +25,6 @@ $icon-colors: (
 .dashboard {
     display: flex;
     min-height: 100vh;
-    flex: 1;
 
     &--text-red {
         color: var(--red);
@@ -57,6 +56,7 @@ $icon-colors: (
         max-width: 1500px;
         margin-inline: auto;
         padding: 0 2rem;
+        flex: 1;
     }
 
     &__user{

--- a/client/src/KnowNativePage/TextPage/TextsPage.scss
+++ b/client/src/KnowNativePage/TextPage/TextsPage.scss
@@ -3,10 +3,10 @@
   display: flex;
 }
 
-.text-page {
-  margin-left: 285px; /* Width of the DashboardNavbar */
-  width: calc(100% - 285px);
-}
+// .text-page {
+//   margin-left: 285px; /* Width of the DashboardNavbar */
+//   width: calc(100% - 285px);
+// }
 
 .text-page__layout {
   display: flex;

--- a/client/src/KnowNativePage/TextPage/TextsPage.scss
+++ b/client/src/KnowNativePage/TextPage/TextsPage.scss
@@ -62,8 +62,13 @@
   color: #555;
 }
 
-/* Tabs styles */
-.tabs{
+/* Read | Study | Tabs styles */
+.tabs {
+  
+  // Check DemoTextPage.scss as we have conflicting class names.
+  // .tabs should be renamed to .text-page__tabs to avoid conflicts.
+  
+  margin-left: 0;
  
     &__compressed {
     display: flex;

--- a/client/src/KnowNativePage/components/DashboardNavbar.scss
+++ b/client/src/KnowNativePage/components/DashboardNavbar.scss
@@ -16,6 +16,9 @@
 
     &__side-nav {
         height: 100vh;
+        position: sticky;
+        top: 0;
+        left: 0;
         border-color: rgb(217, 217, 217);
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
Just a minor styling adjustment to the `DashboardPage.scss` file. The main change is an update to the left and right side padding for the `dashboard__main` container.

* Added horizontal padding (`padding: 0 2rem;`) to the dashboard container to improve alignment. (`client/src/KnowNativePage/DashboardPage/DashboardPage.scss`)