### PR TITLE
Fix Edit Card modal z-index stacking

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -26,8 +26,8 @@
     <title>KnowNative</title>
   </head>
   <body>
-    <div id="portal-modal"></div>
     <div id="root"></div>
+    <div id="portal-modal"></div>
     <script
       src="https://unpkg.com/@dotlottie/player-component@latest/dist/dotlottie-player.mjs"
       type="module"

--- a/client/src/KnowNativePage/DashboardPage/DashboardPage.scss
+++ b/client/src/KnowNativePage/DashboardPage/DashboardPage.scss
@@ -281,7 +281,7 @@ $icon-colors: (
         right: 0;
         bottom: 0;
         background: rgba(0, 0, 0, 0.5);
-        z-index: 9999;
+        z-index: 2000;
         display: flex;
         justify-content: center;
         align-items: center;

--- a/client/src/LandingPages/SignupPage/SignupPage.scss
+++ b/client/src/LandingPages/SignupPage/SignupPage.scss
@@ -80,7 +80,7 @@
 
   &__loading-overlay {
     background: rgba(0, 0, 0, 0.5);
-    z-index: 9999;
+    z-index: 2000;
     position: fixed;
     width: 100%;
     height: 100%;

--- a/client/src/LandingPages/components/ForgotPasswordModal/ForgotPasswordModal.scss
+++ b/client/src/LandingPages/components/ForgotPasswordModal/ForgotPasswordModal.scss
@@ -29,7 +29,7 @@
 
   &__loading-overlay {
     background: rgba(0, 0, 0, 0.5);
-    z-index: 9999;
+    z-index: 2000;
     position: fixed;
     width: 100%;
     height: 100%;

--- a/client/src/LandingPages/components/LandingPageLoginModal/LoginModal.scss
+++ b/client/src/LandingPages/components/LandingPageLoginModal/LoginModal.scss
@@ -55,7 +55,7 @@
 
   &__loading-overlay {
     background: rgba(0, 0, 0, 0.5);
-    z-index: 9999;
+    z-index: 2000;
     position: fixed;
     width: 100%;
     height: 100%;

--- a/client/src/index.scss
+++ b/client/src/index.scss
@@ -262,7 +262,7 @@ a {
   right: 0;
   bottom: 0;
   top: 0;
-  z-index: 9999 !important;
+  z-index: 2000;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/client/src/index.scss
+++ b/client/src/index.scss
@@ -262,7 +262,7 @@ a {
   right: 0;
   bottom: 0;
   top: 0;
-  z-index: 10;
+  z-index: 9999 !important;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/client/src/ui-components/Modal/modal.jsx
+++ b/client/src/ui-components/Modal/modal.jsx
@@ -25,6 +25,7 @@ const Modal = ({
 
   useEffect(() => {
     const modalRoot = document.getElementById('portal-modal');
+    modalRoot.style.zIndex = '9999';
     modalRoot.appendChild(elRef.current);
     // anything you return in a useEffect will run after the component unmounts
     return () => modalRoot.removeChild(elRef.current);

--- a/client/src/ui-components/Slider/slider.jsx
+++ b/client/src/ui-components/Slider/slider.jsx
@@ -168,7 +168,7 @@ const Slider = ({ isOpen, onClose, blurText }) => {
 
   return (
     <>
-      <div ref={sliderRef} className={`slider ${isOpen ? 'open' : ''}`} style={{zIndex: 10}}>
+      <div ref={sliderRef} className={`slider ${isOpen ? 'open' : ''}`}>
         <div className="slider__content">
           <button className="slider__close" aria-label="Close slider" onClick={onClose}>
             ×

--- a/client/src/ui-components/Slider/slider.jsx
+++ b/client/src/ui-components/Slider/slider.jsx
@@ -27,12 +27,14 @@ const Slider = ({ isOpen, onClose, blurText }) => {
 
   useEffect(() => {
     function handleKeyDown(event) {
-      if (event.key === 'Escape') {
+      if (editModalOpen) return;
+      if (event.key === 'Escape') { 
         onClose();
       }
     }
 
     function handleClickOutside(event) {
+      if (editModalOpen) return;
       if (sliderRef.current && !sliderRef.current.contains(event.target)) {
         onClose();
       }
@@ -47,7 +49,7 @@ const Slider = ({ isOpen, onClose, blurText }) => {
       window.removeEventListener('keydown', handleKeyDown);
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, [isOpen, onClose]);
+  }, [isOpen, onClose, editModalOpen]);
 
   function handleOpenFlashcardGameModal() {
     onClose();
@@ -166,7 +168,7 @@ const Slider = ({ isOpen, onClose, blurText }) => {
 
   return (
     <>
-      <div ref={sliderRef} className={`slider ${isOpen ? 'open' : ''}`}>
+      <div ref={sliderRef} className={`slider ${isOpen ? 'open' : ''}`} style={{zIndex: 10}}>
         <div className="slider__content">
           <button className="slider__close" aria-label="Close slider" onClick={onClose}>
             ×

--- a/client/src/ui-components/Slider/slider.scss
+++ b/client/src/ui-components/Slider/slider.scss
@@ -8,7 +8,7 @@
   color: black;
   box-shadow: -2px 0 8px rgba(0, 0, 0, 0.15);
   transition: right 0.3s ease-in-out;
-  z-index: 1000;
+  z-index: 10;
   text-align: left;
 
   &.open {


### PR DESCRIPTION
closes #336 

- Keep Saved Cards drawer open while editing
- Updates reflect after save
- CSS z-index fix so Edit Card modal appears above drawer
- Used inline z-index with CSS fallback since SCSS changes weren’t applying

<img width="931" height="584" alt="image7" src="https://github.com/user-attachments/assets/8c5170f0-43a8-49de-8c45-e15dbb6f5cb5" />

<img width="932" height="584" alt="image8" src="https://github.com/user-attachments/assets/080b1cee-428c-4a92-abfd-58a4ebb118e2" />
