### PR TITLE
Fix #327 - Saved Cards Styling.

### DIFF
--- a/client/src/ui-components/Slider/slider.jsx
+++ b/client/src/ui-components/Slider/slider.jsx
@@ -131,33 +131,31 @@ const Slider = ({ isOpen, onClose, blurText }) => {
 
   const displayWords = savedWords.map((word) => (
     <div key={word._id} className="slider__card">
-      <div className="col">
-        <section className="SavedWord-card__content">
-          <p className="SavedWord-card__char">{word.frontProperties.traditional}</p>
-          <p className="SavedWord-card__char">{word.backProperties.meaning}</p>
-        </section>
-      </div>
-      <div className="col">
+      <section className="slider__card-content" aria-label='Saved Word'>
+        <p className="slider__card-content--savedWord">{word.frontProperties.traditional}</p>
+        <p className="slider__card-content--meaning">{word.backProperties.meaning}</p>
+      </section>
+      <div className="slider__card--options" aria-label='Options Menu'>
         <BiDotsVerticalRounded
-          className={`SavedWord-card__card-icon ${activeCardId === word._id ? 'SavedWord-card__menu-icon--open' : ''}`}
+          className={`options-menu__icon ${activeCardId === word._id ? 'options-menu__icon--open' : ''}`}
           onClick={() => setActiveCardId(activeCardId === word._id ? null : word._id)}
         />
         {/* Menu */}
         {activeCardId === word._id && (
           <article
-            className="SavedWord-card__menu"
+            className="options-menu"
             onMouseEnter={handleMouseEnterMenu}
             onMouseLeave={() => setActiveCardId(null)}>
             <section
-              className="SavedWord-card__menu-button SavedWord-card__menu-button--edit"
+              className="options-menu-button options-menu-button--edit"
               onClick={() => handleEditClick(word)}>
-              <p className="SavedWord-card__menu-label">Edit</p>
+              <p className="options-menu-label">Edit</p>
               <FaPencilAlt />
             </section>
             <section
-              className="SavedWord-card__menu-button SavedWord-card__menu-button--delete"
+              className="options-menu-button options-menu-button--delete"
               onClick={() => handleDeleteCard(word._id)}>
-              <p className="SavedWord-card__menu-label">Delete</p>
+              <p className="options-menu-label">Delete</p>
               <FaTrashAlt />
             </section>
           </article>
@@ -168,7 +166,7 @@ const Slider = ({ isOpen, onClose, blurText }) => {
 
   return (
     <>
-      <div ref={sliderRef} className={`slider ${isOpen ? 'open' : ''}`}>
+      <div ref={sliderRef} className={`slider ${isOpen ? 'slider--open' : ''}`}>
         <div className="slider__content">
           <button className="slider__close" aria-label="Close slider" onClick={onClose}>
             ×
@@ -198,7 +196,7 @@ const Slider = ({ isOpen, onClose, blurText }) => {
           </div>
           <div className="slider__footer">
             {Array.isArray(savedWords) && savedWords.length > 0 && (
-              <div className="dashboard__card-button">
+              <div className="slider__footer-button">
                 <Button
                   iconName="&#xe41d;"
                   iconStyling="reusable-button__icon-flip"

--- a/client/src/ui-components/Slider/slider.jsx
+++ b/client/src/ui-components/Slider/slider.jsx
@@ -27,14 +27,14 @@ const Slider = ({ isOpen, onClose, blurText }) => {
 
   useEffect(() => {
     function handleKeyDown(event) {
-      if (editModalOpen) return;
+      if (editModalOpen || flashcardGameModalOpen) return;
       if (event.key === 'Escape') { 
         onClose();
       }
     }
 
     function handleClickOutside(event) {
-      if (editModalOpen) return;
+      if (editModalOpen || flashcardGameModalOpen) return;
       if (sliderRef.current && !sliderRef.current.contains(event.target)) {
         onClose();
       }
@@ -49,7 +49,7 @@ const Slider = ({ isOpen, onClose, blurText }) => {
       window.removeEventListener('keydown', handleKeyDown);
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, [isOpen, onClose, editModalOpen]);
+  }, [isOpen, onClose, editModalOpen, flashcardGameModalOpen]);
 
   function handleOpenFlashcardGameModal() {
     onClose();
@@ -152,7 +152,7 @@ const Slider = ({ isOpen, onClose, blurText }) => {
 
   return (
     <>
-      <div ref={sliderRef} className={`slider ${isOpen ? 'slider--open' : ''}`}>
+      <div ref={sliderRef} className={`slider ${isOpen ? 'slider--open' : 'slider--close'}`}>
         <div className="slider__content">
           <button className="slider__close" aria-label="Close slider" onClick={onClose}>
             ×
@@ -188,6 +188,7 @@ const Slider = ({ isOpen, onClose, blurText }) => {
                   iconStyling="reusable-button__icon-flip"
                   buttonVariant="tertiary"
                   buttonText="Review"
+                  visibility={isOpen ? true : false}
                   buttonOnClickFunc={handleOpenFlashcardGameModal}
                 />
               </div>

--- a/client/src/ui-components/Slider/slider.jsx
+++ b/client/src/ui-components/Slider/slider.jsx
@@ -111,16 +111,16 @@ const Slider = ({ isOpen, onClose, blurText }) => {
         <p className="slider__card-content--meaning">{word.backProperties.meaning}</p>
       </section>
       {/* 2. Options Icon */}
-      <div className="slider__dropdown-menu" aria-label='Options Menu'>
+      <div className="slider__drawer-menu" aria-label='Options Menu'>
         <BiDotsVerticalRounded
-          className={`slider__dropdown-menu-icon ${activeCardId === word._id ? 'slider__dropdown-menu-icon--open' : ''}`}
+          className={`slider__drawer-menu-icon ${activeCardId === word._id ? 'slider__drawer-menu-icon--open' : ''}`}
           onClick={() => {setActiveCardId(word._id);
           }}
         />
       </div>
       {/* 3. Edit | Delete Options Drawer */}
       <div aria-label='Options:'
-        className={`slider__dropdown-menu-options${activeCardId ? '' : '--hidden'}`}
+        className={`slider__drawer-menu-options${activeCardId ? '' : '--hidden'}`}
         onMouseLeave={() => {
           setActiveCardId(null);
           setShowWordOptions(false);
@@ -128,22 +128,22 @@ const Slider = ({ isOpen, onClose, blurText }) => {
       >
         {/* 3.1 Edit Option */}
         <section aria-label='Edit'
-          className="slider__dropdown-menu-button slider__dropdown-menu-button--edit"
+          className="slider__drawer-menu-button slider__drawer-menu-button--edit"
           onClick={() => {
               handleEditClick(word);
               setShowWordOptions(false);
             }}>
-          <p className="slider__dropdown-menu-label">Edit</p>
+          <p className="slider__drawer-menu-label">Edit</p>
           <FaPencilAlt />
         </section>
         {/* 3.2 Delete Option */}
         <section aria-label='Delete'
-          className="slider__dropdown-menu-button slider__dropdown-menu-button--delete"
+          className="slider__drawer-menu-button slider__drawer-menu-button--delete"
           onClick={() => {
               handleDeleteCard(word._id);
               setShowWordOptions(false);
           }}>
-          <p className="slider__dropdown-menu-label">Delete</p>
+          <p className="slider__drawer-menu-label">Delete</p>
           <FaTrashAlt />
         </section>
       </div>

--- a/client/src/ui-components/Slider/slider.jsx
+++ b/client/src/ui-components/Slider/slider.jsx
@@ -102,37 +102,50 @@ const Slider = ({ isOpen, onClose, blurText }) => {
     }
   };
 
-  const displayWords = savedWords.map((word) => (
-    <div key={word._id} className="slider__card">
+    const displayWords = savedWords.map((word) => (
+    // Saved Cards Container  
+    <div key={word._id} className={`slider__card ${activeCardId == word._id ? 'slider__card--open' : ''}`}>
+      {/* 1. Word and Meaning */}
       <section className="slider__card-content" aria-label='Saved Word'>
         <p className="slider__card-content--savedWord">{word.frontProperties.traditional}</p>
         <p className="slider__card-content--meaning">{word.backProperties.meaning}</p>
       </section>
+      {/* 2. Options Icon */}
       <div className="slider__dropdown-menu" aria-label='Options Menu'>
         <BiDotsVerticalRounded
           className={`slider__dropdown-menu-icon ${activeCardId === word._id ? 'slider__dropdown-menu-icon--open' : ''}`}
-          onClick={() => setActiveCardId(activeCardId === word._id ? null : word._id)}
+          onClick={() => {setActiveCardId(word._id);
+          }}
         />
-        {/* Dropdown Menu */}
-        {activeCardId === word._id && (
-          <article
-            className="slider__dropdown-menu-options"
-            onMouseLeave={() => setActiveCardId(null)}
-          >
-            <section
-              className="slider__dropdown-menu-button slider__dropdown-menu-button--edit"
-              onClick={() => handleEditClick(word)}>
-              <p className="slider__dropdown-menu-label">Edit</p>
-              <FaPencilAlt />
-            </section>
-            <section
-              className="slider__dropdown-menu-button slider__dropdown-menu-button--delete"
-              onClick={() => handleDeleteCard(word._id)}>
-              <p className="slider__dropdown-menu-label">Delete</p>
-              <FaTrashAlt />
-            </section>
-          </article>
-        )}
+      </div>
+      {/* 3. Edit | Delete Options Drawer */}
+      <div aria-label='Options:'
+        className={`slider__dropdown-menu-options${activeCardId ? '' : '--hidden'}`}
+        onMouseLeave={() => {
+          setActiveCardId(null);
+          setShowWordOptions(false);
+        }}
+      >
+        {/* 3.1 Edit Option */}
+        <section aria-label='Edit'
+          className="slider__dropdown-menu-button slider__dropdown-menu-button--edit"
+          onClick={() => {
+              handleEditClick(word);
+              setShowWordOptions(false);
+            }}>
+          <p className="slider__dropdown-menu-label">Edit</p>
+          <FaPencilAlt />
+        </section>
+        {/* 3.2 Delete Option */}
+        <section aria-label='Delete'
+          className="slider__dropdown-menu-button slider__dropdown-menu-button--delete"
+          onClick={() => {
+              handleDeleteCard(word._id);
+              setShowWordOptions(false);
+          }}>
+          <p className="slider__dropdown-menu-label">Delete</p>
+          <FaTrashAlt />
+        </section>
       </div>
     </div>
   ));

--- a/client/src/ui-components/Slider/slider.jsx
+++ b/client/src/ui-components/Slider/slider.jsx
@@ -60,33 +60,6 @@ const Slider = ({ isOpen, onClose, blurText }) => {
     setFlashcardGameModalOpen(false);
   }
 
-  function handleOpenEditModal() {
-    setShowingEditWordModal(true);
-  }
-
-  //clicking the edit icon will open up the menu or close the menu if the menu is already open
-  function handleEditIconClick() {
-    setIsEditMenuOpen((currentState) => !currentState);
-  }
-
-  //if the mouse leaves the saved word card element that is associated with the menu, close the menu if the menu is already open.
-  function handleMouseleaveCard() {
-    if (!isMouseInsideMenu) {
-      setIsEditMenuOpen(false);
-    }
-  }
-
-  //if the mouse enters the menu, set state of IsMouseInsideMenu to TRUE. (it allows you navigate edit or delete buttons as you need to)
-  function handleMouseEnterMenu() {
-    setIsMouseInsideMenu(true);
-  }
-
-  //if you enter the menu and then leave the menu with your mouse, it automatically closes the menu.
-  function handleEditMenuMouseleave() {
-    setIsMouseInsideMenu(false);
-    setIsEditMenuOpen(false);
-  }
-
   const handleEditClick = (word) => {
     setSelectedWord(word);
     setEditModalOpen(true);
@@ -135,27 +108,27 @@ const Slider = ({ isOpen, onClose, blurText }) => {
         <p className="slider__card-content--savedWord">{word.frontProperties.traditional}</p>
         <p className="slider__card-content--meaning">{word.backProperties.meaning}</p>
       </section>
-      <div className="slider__card--options" aria-label='Options Menu'>
+      <div className="slider__dropdown-menu" aria-label='Options Menu'>
         <BiDotsVerticalRounded
-          className={`options-menu__icon ${activeCardId === word._id ? 'options-menu__icon--open' : ''}`}
+          className={`slider__dropdown-menu-icon ${activeCardId === word._id ? 'slider__dropdown-menu-icon--open' : ''}`}
           onClick={() => setActiveCardId(activeCardId === word._id ? null : word._id)}
         />
-        {/* Menu */}
+        {/* Dropdown Menu */}
         {activeCardId === word._id && (
           <article
-            className="options-menu"
-            onMouseEnter={handleMouseEnterMenu}
-            onMouseLeave={() => setActiveCardId(null)}>
+            className="slider__dropdown-menu-options"
+            onMouseLeave={() => setActiveCardId(null)}
+          >
             <section
-              className="options-menu-button options-menu-button--edit"
+              className="slider__dropdown-menu-button slider__dropdown-menu-button--edit"
               onClick={() => handleEditClick(word)}>
-              <p className="options-menu-label">Edit</p>
+              <p className="slider__dropdown-menu-label">Edit</p>
               <FaPencilAlt />
             </section>
             <section
-              className="options-menu-button options-menu-button--delete"
+              className="slider__dropdown-menu-button slider__dropdown-menu-button--delete"
               onClick={() => handleDeleteCard(word._id)}>
-              <p className="options-menu-label">Delete</p>
+              <p className="slider__dropdown-menu-label">Delete</p>
               <FaTrashAlt />
             </section>
           </article>
@@ -185,7 +158,7 @@ const Slider = ({ isOpen, onClose, blurText }) => {
               </div>
             )}
 
-            {/* Placeholder cards */}
+            {/* Show the user's Saved Words (displayWords) or render a placeholder message*/}
             {displayWords.length > 0 ? (
               displayWords
             ) : (

--- a/client/src/ui-components/Slider/slider.scss
+++ b/client/src/ui-components/Slider/slider.scss
@@ -3,9 +3,9 @@
 // ----------------------------------
 
 // Left and Right Padding Values:
-$saved-card-LR-padding: 1rem;
+$saved-card-LR-padding: 1.6rem;
 // Top and Bottom Padding Values:
-$saved-card-TB-padding: 0.8rem;
+$saved-card-TB-padding: 1.2rem;
 // Bottom Margin Value:
 $saved-card-bottom-margin: 0.1rem;
 

--- a/client/src/ui-components/Slider/slider.scss
+++ b/client/src/ui-components/Slider/slider.scss
@@ -91,7 +91,7 @@ $saved-card-bottom-margin: 0.1rem;
     }
   }
 
-  &__dropdown-menu {
+  &__drawer-menu {
     grid-area: icon;
     padding: $saved-card-LR-padding;
 

--- a/client/src/ui-components/Slider/slider.scss
+++ b/client/src/ui-components/Slider/slider.scss
@@ -143,6 +143,7 @@ $saved-card-bottom-margin: 0.1rem;
       &--delete {
         background-color: #fddddd;
         color: #b00020;
+        flex: 1;
       }
 
       &:hover {

--- a/client/src/ui-components/Slider/slider.scss
+++ b/client/src/ui-components/Slider/slider.scss
@@ -24,6 +24,15 @@ $saved-card-bottom-margin: 0.1rem;
     justify-self: right;
     position: sticky;
     top: 0;
+    visibility: visible;
+    opacity: 1;
+    transition: opacity 0.3s ease-in;
+  }
+
+  &--close {
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity 0.3s ease;
   }
 
   &__content {
@@ -166,9 +175,8 @@ $saved-card-bottom-margin: 0.1rem;
     display: flex;
 
     &-button {
-        min-width: 100%;
+        width: 100%;
         height: 100%;
-        display: hidden;
         flex: 1;
         & > button {
           width: 100%;

--- a/client/src/ui-components/Slider/slider.scss
+++ b/client/src/ui-components/Slider/slider.scss
@@ -1,8 +1,12 @@
-// --------------------------
-// -- SAVED CARD VARIABLES --
-// --------------------------
+// ----------------------------------
+// -- SAVED CARD STYLING VARIABLES --
+// ----------------------------------
+
+// Left and Right Padding Values:
 $saved-card-LR-padding: 1rem;
+// Top and Bottom Padding Values:
 $saved-card-TB-padding: 0.8rem;
+// Bottom Margin Value:
 $saved-card-bottom-margin: 0.1rem;
 
 .slider {
@@ -156,17 +160,19 @@ $saved-card-bottom-margin: 0.1rem;
   }
 
   &__footer {
-    padding-top: 1rem;
+    padding-top: 2rem;
+    padding-bottom: 2rem;
     border-top: 1px solid #ddd;
     display: flex;
-    justify-content: center;
 
     &-button {
-      width: 100%;
-
-      Button {
-        width: 100%;
-      }
+        min-width: 100%;
+        height: 100%;
+        display: hidden;
+        flex: 1;
+        & > button {
+          width: 100%;
+        }
     }
   }
 

--- a/client/src/ui-components/Slider/slider.scss
+++ b/client/src/ui-components/Slider/slider.scss
@@ -57,10 +57,6 @@
     align-items: center;
     padding: 1rem;
     margin-bottom: 0.1rem;
-    
-    &--options {
-      flex-shrink: 2;
-    }
 
     &-content {
       flex: 1;
@@ -73,6 +69,62 @@
 
       &--meaning {
         margin-bottom: 0;
+      }
+    }
+  }
+
+  &__dropdown-menu {
+    position: relative;
+
+    &-options {
+      position: absolute;
+      right: 100%; // Ensures it's aligned within the card
+      background-color: white;
+      border-radius: 6px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+      z-index: 10;
+      min-width: 120px;
+      min-height: 120px;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+    }
+
+    &-button {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      // padding: 0.75rem 1rem;
+      font-size: 1rem;
+      cursor: pointer;
+
+      &--edit {
+        background-color: #e6f7f7;
+        color: #333;
+      }
+
+      &--delete {
+        background-color: #fddddd;
+        color: #b00020;
+      }
+
+      &:hover {
+        background-color: #ddd;
+      }
+    }
+
+    &-label {
+      margin: 0;
+      padding: 1rem;
+    }
+
+    &-icon {
+      border-radius: 50%;
+
+      &:hover {
+        background-color: #086a6c25;
+        cursor: pointer;
       }
     }
   }
@@ -104,121 +156,6 @@
 
     &:hover {
       background-color: #074b59;
-    }
-  }
-}
-
-// .SavedWord-card {
-//   &__menu {
-//         position: absolute;
-//         top: 1.5rem; // Adjust based on your icon placement
-//         right: 0.02rem; // Ensures it's aligned within the card
-//         background-color: white;
-//         border-radius: 6px;
-//         box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-//         z-index: 10;
-//         min-width: 120px;
-//         overflow: hidden;
-
-//         display: flex;
-//         flex-direction: column;
-
-//         &-button {
-//           display: flex;
-//           justify-content: space-between;
-//           align-items: center;
-//           padding: 0.75rem 1rem;
-//           font-size: 1rem;
-//           cursor: pointer;
-
-//           &--edit {
-//             background-color: #e6f7f7;
-//             color: #333;
-//           }
-
-//           &--delete {
-//             background-color: #fddddd;
-//             color: #b00020;
-//           }
-
-//           &:hover {
-//             background-color: #ddd;
-//           }
-//         }
-
-//         &__menu-label {
-//           margin-right: 0.5rem;
-//         }
-//       }
-//   &__content {
-//         display: flex;
-//         flex-direction: column;
-//         padding: 0.5rem;
-//       }
-//   &__char {
-//         font-size: 1.2rem;
-//         font-weight: 400;
-//         color: #333;
-//       }
-// }
-
-.options-menu {
-        position: absolute;
-        top: 1.5rem; // Adjust based on your icon placement
-        right: 0.02rem; // Ensures it's aligned within the card
-        background-color: white;
-        border-radius: 6px;
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-        z-index: 10;
-        min-width: 120px;
-        overflow: hidden;
-
-        display: flex;
-        flex-direction: column;
-
-        &-button {
-          display: flex;
-          justify-content: space-between;
-          align-items: center;
-          padding: 0.75rem 1rem;
-          font-size: 1rem;
-          cursor: pointer;
-
-          &--edit {
-            background-color: #e6f7f7;
-            color: #333;
-          }
-
-          &--delete {
-            background-color: #fddddd;
-            color: #b00020;
-          }
-
-          &:hover {
-            background-color: #ddd;
-          }
-        }
-
-        &-label {
-          margin-right: 0.5rem;
-        }
-      
-  &__content {
-        display: flex;
-        flex-direction: column;
-        padding: 0.5rem;
-      }
-  &__char {
-        font-size: 1.2rem;
-        font-weight: 400;
-        color: #333;
-      }
-  
-    &__icon {
-      border-radius: 50%;
-      &:hover {
-        background-color: #086a6c25;    
-        cursor: pointer;
     }
   }
 }

--- a/client/src/ui-components/Slider/slider.scss
+++ b/client/src/ui-components/Slider/slider.scss
@@ -1,5 +1,12 @@
+// --------------------------
+// -- SAVED CARD VARIABLES --
+// --------------------------
+$saved-card-LR-padding: 1rem;
+$saved-card-TB-padding: 0.8rem;
+$saved-card-bottom-margin: 0.1rem;
+
 .slider {
-  right: -100%;
+  right: 0%;
   // The slider height needs to account for the .dashboard__user-info header.
   height: calc(100dvh - 5rem);
   background-color: #f2f5f5;
@@ -53,13 +60,24 @@
 
   &__card {
     background: #ffffff;
-    display: flex;
+    display: grid;
+    grid-template-columns: 1fr auto 0px;
+    grid-template-areas: "content icon options";
     align-items: center;
-    padding: 1rem;
-    margin-bottom: 0.1rem;
+    margin-bottom: $saved-card-bottom-margin;
+    overflow: hidden;
+    transition: grid-template-columns 200ms ease;
+    will-change: grid-template-columns;
+
+    &--open {
+      grid-template-areas: "content icon options";
+      grid-template-columns: 1fr 0px 30%;
+      transition: grid-template-columns 300ms ease;
+    }
 
     &-content {
-      flex: 1;
+      grid-area: content;
+      padding: $saved-card-TB-padding $saved-card-LR-padding;
 
       &--savedWord {
         font-size: 1.6rem;
@@ -74,34 +92,39 @@
   }
 
   &__dropdown-menu {
-    position: relative;
+    grid-area: icon;
+    padding: $saved-card-LR-padding;
 
     &-options {
-      position: absolute;
-      right: 100%; // Ensures it's aligned within the card
-      background-color: white;
-      border-radius: 6px;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-      z-index: 10;
-      min-width: 120px;
-      min-height: 120px;
-      overflow: hidden;
+      grid-area: options;
       display: flex;
-      flex-direction: column;
-      justify-content: center;
+      flex-direction: row;
+      width: 100%;
+      height: 100%;
+
+      &--hidden {
+        display: none;
+      }
     }
 
     &-button {
       display: flex;
-      justify-content: space-between;
+      justify-content: center;
+      row-gap: 1rem;
+      flex-direction: column-reverse;
       align-items: center;
-      // padding: 0.75rem 1rem;
-      font-size: 1rem;
+      font-size: 0.9rem;
       cursor: pointer;
+
+       & > svg {
+        padding: 0 0.6rem;
+        width: fit-content;
+      }
 
       &--edit {
         background-color: #e6f7f7;
         color: #333;
+        flex: 1;
       }
 
       &--delete {
@@ -116,11 +139,14 @@
 
     &-label {
       margin: 0;
-      padding: 1rem;
+      padding: 0 0.6rem;
     }
 
     &-icon {
       border-radius: 50%;
+      height: 1.5em;
+      width: 1.5em;
+      color: #086A6C;
 
       &:hover {
         background-color: #086a6c25;

--- a/client/src/ui-components/Slider/slider.scss
+++ b/client/src/ui-components/Slider/slider.scss
@@ -3,7 +3,7 @@
 // ----------------------------------
 
 // Left and Right Padding Values:
-$saved-card-LR-padding: 1.6rem;
+$saved-card-LR-padding: 1.8rem;
 // Top and Bottom Padding Values:
 $saved-card-TB-padding: 1.2rem;
 // Bottom Margin Value:

--- a/client/src/ui-components/Slider/slider.scss
+++ b/client/src/ui-components/Slider/slider.scss
@@ -9,7 +9,7 @@
   text-align: left;
   grid-area: slider;
 
-  &.open {
+  &--open {
     justify-self: right;
     position: sticky;
     top: 0;
@@ -53,17 +53,116 @@
 
   &__card {
     background: #ffffff;
-    display: grid;
-    grid-template-columns: 1fr auto;
+    display: flex;
+    align-items: center;
     padding: 1rem;
-    border-radius: 8px;
     margin-bottom: 0.1rem;
+    
+    &--options {
+      flex-shrink: 2;
+    }
 
-    .col {
-      align-self: center;
-      position: relative;
+    &-content {
+      flex: 1;
 
-      .SavedWord-card__menu {
+      &--savedWord {
+        font-size: 1.6rem;
+        font-weight: light;
+        margin-bottom: 0;
+      }
+
+      &--meaning {
+        margin-bottom: 0;
+      }
+    }
+  }
+
+  &__footer {
+    padding-top: 1rem;
+    border-top: 1px solid #ddd;
+    display: flex;
+    justify-content: center;
+
+    &-button {
+      width: 100%;
+
+      Button {
+        width: 100%;
+      }
+    }
+  }
+
+  &__confirm {
+    background-color: #086a6c;
+    color: white;
+    padding: 0.75rem 2rem;
+    font-size: 1rem;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+
+    &:hover {
+      background-color: #074b59;
+    }
+  }
+}
+
+// .SavedWord-card {
+//   &__menu {
+//         position: absolute;
+//         top: 1.5rem; // Adjust based on your icon placement
+//         right: 0.02rem; // Ensures it's aligned within the card
+//         background-color: white;
+//         border-radius: 6px;
+//         box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+//         z-index: 10;
+//         min-width: 120px;
+//         overflow: hidden;
+
+//         display: flex;
+//         flex-direction: column;
+
+//         &-button {
+//           display: flex;
+//           justify-content: space-between;
+//           align-items: center;
+//           padding: 0.75rem 1rem;
+//           font-size: 1rem;
+//           cursor: pointer;
+
+//           &--edit {
+//             background-color: #e6f7f7;
+//             color: #333;
+//           }
+
+//           &--delete {
+//             background-color: #fddddd;
+//             color: #b00020;
+//           }
+
+//           &:hover {
+//             background-color: #ddd;
+//           }
+//         }
+
+//         &__menu-label {
+//           margin-right: 0.5rem;
+//         }
+//       }
+//   &__content {
+//         display: flex;
+//         flex-direction: column;
+//         padding: 0.5rem;
+//       }
+//   &__char {
+//         font-size: 1.2rem;
+//         font-weight: 400;
+//         color: #333;
+//       }
+// }
+
+.options-menu {
         position: absolute;
         top: 1.5rem; // Adjust based on your icon placement
         right: 0.02rem; // Ensures it's aligned within the card
@@ -100,52 +199,26 @@
           }
         }
 
-        &__menu-label {
+        &-label {
           margin-right: 0.5rem;
         }
-      }
-
-      .SavedWord-card__content {
+      
+  &__content {
         display: flex;
         flex-direction: column;
         padding: 0.5rem;
-
-        .SavedWord-card__char {
-          font-size: 1.2rem;
-          font-weight: 400;
-          color: #333;
-        }
       }
-    }
-  }
-
-  &__footer {
-    padding-top: 1rem;
-    border-top: 1px solid #ddd;
-    display: flex;
-    justify-content: center;
-
-    .dashboard__card-button {
-      width: 100%;
-
-      Button {
-        width: 100%;
+  &__char {
+        font-size: 1.2rem;
+        font-weight: 400;
+        color: #333;
       }
-    }
-  }
-
-  &__confirm {
-    background-color: #086a6c;
-    color: white;
-    padding: 0.75rem 2rem;
-    font-size: 1rem;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    transition: background-color 0.3s ease;
-
-    &:hover {
-      background-color: #074b59;
+  
+    &__icon {
+      border-radius: 50%;
+      &:hover {
+        background-color: #086a6c25;    
+        cursor: pointer;
     }
   }
 }


### PR DESCRIPTION
## Description
This PR fixes #327 by refactoring and improving the styling and functionality of the Saved Cards slider component.

## Main Changes:

### Styling Improvements
- Refactored slider component classNames for better clarity and maintainability.
- Renamed dropdown menu to drawer menu to better reflect its new sliding behavior.
- Adjusted saved card values according to our [Figma designs](https://www.figma.com/design/EqPH1otHNLl7NI3AML3VbU/KnowNative-v2?node-id=1915-11594&p=f&t=qO453qTI3JcUI54v-0):
  - Set left and right padding to 1.8rem
  - Optimized top and bottom padding to 1.2rem
  - Removed border radius.
  - Reduced height of each of the cards.
  - Adjusted font sizes.
  - Adjusted the triple dot menu icon size and color.
- Added SCSS variables for future adjustments to the saved card styling (`$saved-card-LR-padding`, `$saved-card-TB-padding`, `$saved-card-bottom-margin`).

### Functionality Enhancements
- Upgraded to animated sliding drawer menu for edit/delete options (check out the demo video below).
- Fixed Review button padding for better alignment.
- Fixed a bug where slider would incorrectly display after Flashcard Game closes.

### Code Cleanup.
- Cleaned up slider component JSX structure, removing all unused functions.
- Polished classNames throughout the component.
- Improved stylesheet organization.

## Testing
- [x] Verified slider opens and closes correctly on different screen sizes.
- [x] Confirmed drawer menu animations work smoothly on different browsers (unsupported browsers should still be able to see the slider opening and closing without an animation).
- [x] Tested Review button functionality.
- [x] Verified Flashcard Game modal interaction doesn't affect slider state.

## Demo Video
https://github.com/user-attachments/assets/830ac5ea-514c-46fa-aad5-26bc816d1f4b

## Related Issue
Fixes #327