### PR TITLE
Fix flashcard game end screen text alignment and button copy

### DIFF
--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.jsx
@@ -263,7 +263,7 @@ export default function FlashcardGameModal({ selectedFront = 'chinese', showPiny
                                 className="flashcard-buttons__incorrect-btn"
                                 onClick={handleIncorrect}>
                                 <PiRepeatBold className="flashcard-buttons__icon" />
-                                Try again
+                                Wrong
                             </button>
                         </div> 
                         : 

--- a/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.scss
+++ b/client/src/KnowNativePage/components/FlashcardGameModal/FlashcardGameModal.scss
@@ -27,6 +27,7 @@
   &__congrats-msg {
     @include flex-center;
     flex-direction: column;
+    text-align: center;
   }
 }
 


### PR DESCRIPTION
Closes #337

-  Centered message "You completed the deck!" on the end screen of the Flashcard Game
-  Updated button text "Wrong" in the Flashcard Game

<img width="352" height="320" alt="image2" src="https://github.com/user-attachments/assets/007c8433-eacd-454a-8c0c-51bb500fa656" />
<img width="354" height="324" alt="image1" src="https://github.com/user-attachments/assets/f280f534-0ff2-4f64-8cb0-2fdd3a4045c9" />

