### PR TITLE
Reposition the Log in Form.

### DIFF
--- a/client/src/LandingPages/LoginPage/LoginPage.jsx
+++ b/client/src/LandingPages/LoginPage/LoginPage.jsx
@@ -2,6 +2,7 @@ import { useState, useReducer } from 'react';
 import './LoginPage.scss';
 import { Link } from 'react-router-dom';
 import LandingPageNav from '../components/LandingPageHeader/LandingPageNav';
+import LandingPageFooter from '../components/LandingPageFooter/LandingPageFooter';
 import * as authService from '../../services/authService';
 import { useNavigate } from 'react-router-dom';
 import { useAuthContext } from '../../contexts/Auth/AuthProvider';
@@ -212,7 +213,7 @@ export default function LoginPage() {
   }
 
   return (
-    <main>
+    <main className='login-page'>
       <LandingPageNav />
       <div className="login-page__form-container">
         <div className="login-page__container">
@@ -281,6 +282,7 @@ export default function LoginPage() {
           )}
         </div>
       </div>
+      <LandingPageFooter />
       
       {currentModal === MODAL_STATES.FORGOT_PASSWORD && (
         <ForgotPasswordModal setShowModal={handleCloseForgotPassword} />

--- a/client/src/LandingPages/LoginPage/LoginPage.scss
+++ b/client/src/LandingPages/LoginPage/LoginPage.scss
@@ -1,6 +1,8 @@
 .login-page {
   $deep-red: #962828;
   min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 
   &__forgot,
   &__signup-link {
@@ -17,6 +19,7 @@
   &__form-container {
     display: flex;
     align-items: center;
+    flex: 1;
     justify-content: center;
     flex-direction: column;
     padding-left: 30px;


### PR DESCRIPTION
This PR fixes #338 - Reposition the Log In Form.

## Summary of Changes:
- Adds the class name `login-page` to the `<main>` container of the login page to initialize `display: flex`.
- `login-page__form-container` is assigned a **flex** value of **1**, so that it takes up all the available space within it's parent container.
- Adds the `<LandingPageFooter>` component to the log in page, so that it looks as close as possible to the [Figma Designs](https://www.figma.com/design/EqPH1otHNLl7NI3AML3VbU/KnowNative-v2?node-id=1915-11594&p=f&t=qO453qTI3JcUI54v-0).

## Screenshot:
<img width="1612" height="1258" alt="image" src="https://github.com/user-attachments/assets/38860037-4aaa-4691-a824-72d3cdd43cc7" />


## Note to Reviewers:
- Navigate to `localhost:3000/login` to see the form.

## Future Fixes:
- `SignupPage.jsx` needs a similar fix. I'll create a new GitHub issue to document the problem.