### PR TITLE
Reposition the Signup Form, Fix Input Validation, Add Footer.

### DIFF
--- a/client/src/LandingPages/SignupPage/SignupPage.jsx
+++ b/client/src/LandingPages/SignupPage/SignupPage.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import './SignupPage.scss';
 import { Link, useNavigate } from 'react-router-dom';
 import LandingPageNav from '../components/LandingPageHeader/LandingPageNav';
+import LandingPageFooter from '../components/LandingPageFooter/LandingPageFooter';
 import FormInput from '../components/Forms/FormInput/FormInput';
 import PasswordValidation from '../components/Forms/PasswordValidation';
 import * as authService from '../../services/authService';
@@ -280,6 +281,7 @@ const SignupPage = () => {
           </>
         )}
       </section>
+      <LandingPageFooter />
     </main>
   );
 };

--- a/client/src/LandingPages/SignupPage/SignupPage.scss
+++ b/client/src/LandingPages/SignupPage/SignupPage.scss
@@ -1,15 +1,26 @@
+$gap-between-fields: 1.8rem;
+
 .signup-page {
+
+  &__main {
+    height: 100dvh;
+    display: flex;
+    flex-direction: column;
+  }
+
   &__container {
-    display: grid;
-    grid-template-columns: 1fr;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
     margin-inline: auto;
+    flex: 1;
   }
 
   &__title {
     font-size: 1.5rem;
     text-align: center;
     color: black;
-    padding: 1em 0 0 0;
+    padding: 1.5rem;
   }
 
   &__error-message {
@@ -21,10 +32,9 @@
   &__form {
     display: flex;
     flex-direction: column;
-    gap: 0.8em;
+    gap: $gap-between-fields;
     align-items: center;
     justify-content: center;
-    padding: 0 160px;
   }
 
   &__button {
@@ -70,7 +80,7 @@
 
   &__login-link {
     color: black;
-    font-size: 14px;
+    font-size: 1rem;
     text-align: center;
   }
 
@@ -108,7 +118,7 @@
   &--hidden {
     max-height: 0px;
     opacity: 0;
-    margin-top: -12px;
+    margin-top: - $gap-between-fields;
   }
 }
 


### PR DESCRIPTION
This PR fixes #354

## Main Changes:
- Initializes flexbox on the `signup-page__main` component and makes it extend to full height (`height: 100 dvh`).
 - `signup-page__container`
   - Makes this container Flexbox instead of CSS Grid.
   - Assigns the property of `flex: 1` so that it takes up all of the available space.
   - Justifies the content to the center of the screen.
- Adds a variable to manipulate the gap between rows of input fields: `$gap-between-fields` - This change makes the input validation messages visible.
- Adds the `<LandingPageFooter>` component to the bottom of the screen.

## Screenshots:
### Signup Form Layout:
<img width="1404" height="1265" alt="image" src="https://github.com/user-attachments/assets/cd91888d-8088-4847-8a0c-bfd063b8fbda" />

### Input Fields Displaying Error Messages:
<img width="1383" height="1255" alt="image" src="https://github.com/user-attachments/assets/4149ab5e-dc5e-4629-ad2a-15299e6f0511" />


