### PR TITLE
Remove Duplicate User Dropdown Panel in Dashboard.

### DIFF
--- a/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
+++ b/client/src/KnowNativePage/DashboardPage/DashboardPage.jsx
@@ -199,20 +199,6 @@ export default function DashboardPage() {
               />
               <p className="dashboard__user-dropdown-icon">{isUserDropdownOpen ? '┓' : '┕'}</p>
             </button>
-        <div className="dashboard__user-info">
-          <div className="dashboard__user-dropdown">
-            <button
-              className="dashboard__user-dropdown-options"
-              onClick={() => setIsUserDropdownOpen((prev) => !prev)}>
-              <p className="dashboard__user-name">{user.username}</p>
-              <img
-                className="dashboard__user-profile-pic"
-                src="/images/square-logo.png"
-                alt="User profile picture."
-              />
-              <p className="dashboard__user-dropdown-icon">{isUserDropdownOpen ? '┓' : '┕'}</p>
-            </button>
-
             {isUserDropdownOpen && (
               <div className="dashboard__user-dropdown-panel">
                 <p>
@@ -224,18 +210,16 @@ export default function DashboardPage() {
               </div>
             )}
           </div>
-        </div>
-            {isUserDropdownOpen && (
-              <div className="dashboard__user-dropdown-panel">
-                <p>
-                  <strong>
-                    {user.firstName} {user.lastName}
-                  </strong>
-                </p>
-                <p>Joined {new Date(user.createdAt).toLocaleDateString()}</p>
-              </div>
-            )}
-          </div>
+          {isUserDropdownOpen && (
+            <div className="dashboard__user-dropdown-panel">
+              <p>
+                <strong>
+                  {user.firstName} {user.lastName}
+                </strong>
+              </p>
+              <p>Joined {new Date(user.createdAt).toLocaleDateString()}</p>
+            </div>
+          )}
         </div>
         <div className="dashboard__title">
           {/*Just added user.username for testing of the token. Please adjust as needed. */}


### PR DESCRIPTION
# Fix: Remove duplicate user dropdown panel in Dashboard
This PR fixes #339 

## Problem
The Dashboard component was rendering the user dropdown panel twice: once inside the `dashboard__user-dropdown` div and again inside `dashboard__user-info`. 

## Solution
Removed the duplicate `dashboard__user-dropdown-panel` div that was incorrectly placed outside of the `dashboard__user-dropdown` container.

## Screenshot:

<img width="2311" height="1354" alt="image" src="https://github.com/user-attachments/assets/c177b47d-7540-414c-a0e2-938e575f865b" />
