### PR TITLE
[New Feature] Token Caching for Study Tab

### DIFF
--- a/client/src/KnowNativePage/TextPage/StudyTab.jsx
+++ b/client/src/KnowNativePage/TextPage/StudyTab.jsx
@@ -4,7 +4,7 @@ import "./StudyTab.scss";
 import WordPopup from "./components/WordPopup/WordPopup";
 import Spinner from "../../ui-components/Spinner/spinner.jsx";
 
-export default function StudyTab({ text }) {
+export default function StudyTab({ text, tokenCacheRef }) {
   const [tokens, setTokens] = useState([]);
   const [activeWord, setActiveWord] = useState(null);
   const [detectedLanguage, setDetectedLanguage] = useState(null);
@@ -21,26 +21,58 @@ export default function StudyTab({ text }) {
       rect: e.target.getBoundingClientRect(), // store click position for popup placement
     });
   }
-  
-  useEffect(() => {
-    async function fetchTokens() {
-      if (!text?.content) return;
-      setIsLoading(true);
-      try {
-        const { tokens, detectedLanguage } = await getTextTokens(text._id);
-        setDetectedLanguage(detectedLanguage);
-        setTokens(
-          tokens.map((token) => ( { text: token.word, ...token } ))
-        );
+
+  function cacheTokens(textId, tokens, detectedLanguage) {
+    if (!textId || !tokens) return;
+
+    tokenCacheRef.current = {
+      cachedTextId: textId,
+      cachedTokens: tokens,
+      cachedDetectedLanguage: detectedLanguage,
+    };
+  }
+
+  async function fetchTokens() {
+    
+    if (!text?.content) return;
+
+    // Check if the token cache exists.
+    if (tokenCacheRef.current) {
+      
+      const { cachedTextId, cachedTokens, cachedDetectedLanguage } = tokenCacheRef.current;
+      
+      // IF the current text's ._id matches the cachedtextID, 
+      // use the cached tokens and detected language to set state.
+      if (cachedTextId === text._id) {
+        setTokens(cachedTokens.map((token) => ({ text: token.word, ...token })));
+        setDetectedLanguage(cachedDetectedLanguage);
         setIsLoading(false);
-      } catch (err) {
-        console.error("Tokenization failed:", err);
-        setTokens([{ text: text.content }]); // fallback to displaying the full text.
-        setIsLoading(false);
+        return;
       }
     }
+
+    // IF tokens for this text are not cached:
+    // Fetch the tokens and detected language from the database.
+    // Cache the response.
+    setIsLoading(true);
+    try {
+      const { tokens, detectedLanguage } = await getTextTokens(text._id);
+      setDetectedLanguage(detectedLanguage);
+      setTokens(
+        tokens.map((token) => ( { text: token.word, ...token } ))
+      );
+      cacheTokens(text._id, tokens, detectedLanguage);
+    } catch (err) {
+      setTokens([{ text: text.content }]); // fallback to displaying the full text if fetching fails.
+      setDetectedLanguage('');
+    } finally {
+      setIsLoading(false);
+    }
+  }  
+
+  useEffect(() => {
     fetchTokens();
-  }, [text]);
+  }, [text, tokenCacheRef]);
 
   return (
     <section className="study">

--- a/client/src/KnowNativePage/TextPage/TextsPage.jsx
+++ b/client/src/KnowNativePage/TextPage/TextsPage.jsx
@@ -17,6 +17,7 @@ export default function TextsPage() {
   const [text, setText] = useState(location.state?.text || null);
   const [isSliderOpen, setIsSliderOpen] = useState(false);
   const blurRef = useRef(null);
+  const tokenCacheRef = useRef(null);
 
   function handleTabClick(tabName) {
     setActiveTab(tabName);
@@ -157,7 +158,7 @@ export default function TextsPage() {
             )}
 
             <div>
-              {activeTab === 'study' && <StudyTab text={text} />}
+              {activeTab === 'study' && <StudyTab text={text} tokenCacheRef={tokenCacheRef} />}
               {activeTab === 'translate' && <p>This is the Translate tab.</p>}
             </div>
           </div>


### PR DESCRIPTION
# Token Caching for Study Tab

## Summary
Implements client-side caching for tokenized text data to eliminate multiple hits to the database when users switch between _READ | STUDY | TRANSALATE_ tabs for one same text.

## Problem
Previously, every time a user switched between tabs, the `useEffect()` hook in `StudyTab.jsx` component would fetch tokens from the database, even if those tokens had already been retrieved in the same session. This resulted in:
- Unnecessary API calls
- Slower user experience

## Solution
- Added a `useRef` hook in the parent component `TextPage.jsx` as a caching mechanism that stores tokenized text data in memory during the user's session.

## Changes Made
### 1. `TextsPage.jsx` : 
- Added `tokenCacheRef` using `useRef(null)` to persist cache when the child component `StudyTab.jsx` mounts and unmounts.
- Passed tokenCacheRef as a prop to the StudyTab component
### 2. `StudyTab.jsx`:
- Added `cacheTokens()` helper function to store tokens in the ref.
- Modified fetchTokens() to check cache before making API calls:
  - If cached data exists for current text → use cached data
  - If no cache or different text → fetch from database and cache result

This PR closes #358 