### PR TITLE
Fix Navbar Login Link Navigation

### DIFF
--- a/client/src/LandingPages/components/LandingPageHeader/LandingPageNav.jsx
+++ b/client/src/LandingPages/components/LandingPageHeader/LandingPageNav.jsx
@@ -45,7 +45,7 @@ export default function LandingPageNav({ setShowLoginModal }) {
               </a>
             </li>
             <li className="nav-item">
-              <Link className="nav-link" onClick={setShowLoginModal}>
+              <Link className="nav-link" to="/login">
                 Login
               </Link>
             </li>


### PR DESCRIPTION
Closes #342 

## Fix: Navbar Login Link Navigation

### Changes
- Updated the Login link in `LandingPageNav.jsx` component to use `to="/login"` instead of `onClick={setShowLoginModal}`

### Why?
- The link was broken.
- This change aligns with the existing pattern used by other navigation links (About, Blog, Contribute, etc.)
